### PR TITLE
update all pokemon info

### DIFF
--- a/settings/math.js
+++ b/settings/math.js
@@ -11,7 +11,7 @@ FullScreenPokemon.prototype.settings.math = {
                     "types": constants.pokemon[title].types,
                     "IV": iv || this.compute("newPokemonIVs"),
                     "EV": ev || this.compute("newPokemonEVs"),
-                    "experience": this.compute("newPokemonExperience", title, level)
+                    "experience": this.compute("experienceStarting", title, level)
                 },
                 i;
 
@@ -98,18 +98,6 @@ FullScreenPokemon.prototype.settings.math = {
             numerator = (iv + base + (Math.sqrt(ev) / 8) + topExtra) * level;
 
             return (numerator / 50 + added) | 0;
-        },
-        // Wild Pok�mon of any level will always have the base amount of experience required to reach that level when caught, as will Pok�mon hatched from Eggs.
-        "newPokemonExperience": function (NumberMaker, constants, equations, title, level) {
-            var levelCurrent = this.compute("experienceAtLevel", title, level),
-                levelNext = this.compute("experienceAtLevel", title, level + 1);
-
-            return {
-                "current": levelCurrent,
-                "levelCurrent": levelCurrent,
-                "levelNext": levelNext,
-                "remaining": levelNext - levelCurrent
-            };
         },
         // http://bulbapedia.bulbagarden.net/wiki/Tall_grass
         "doesGrassEncounterHappen": function (NumberMaker, constants, equations, grass) {
@@ -232,7 +220,7 @@ FullScreenPokemon.prototype.settings.math = {
                 return NumberMaker.randomArrayMember(possibilities).move;
             }
 
-            // Modification 1: Do not use a move that only statuses (e.g. Thunder Wave) if the player's pok�mon already has a status.
+            // Modification 1: Do not use a move that only statuses (e.g. Thunder Wave) if the player's pokémon already has a status.
             if (player.selectedActor.status && !opponent.dumb) {
                 for (i = 0; i < possibilities.length; i += 1) {
                     if (equations.moveOnlyStatuses(possibilities[i].move)) {
@@ -241,7 +229,7 @@ FullScreenPokemon.prototype.settings.math = {
                 }
             }
 
-            // Modification 2: On the second turn the pok�mon is out, prefer a move with one of the following effects...
+            // Modification 2: On the second turn the pokémon is out, prefer a move with one of the following effects...
             if (
                 equations.opponentMatchesTypes(
                     opponent,
@@ -448,7 +436,8 @@ FullScreenPokemon.prototype.settings.math = {
             return total;
         },
         // http://m.bulbapedia.bulbagarden.net/wiki/Experience#Relation_to_level
-        "experienceAtLevel": function (NumberMaker, constants, equations, title, level) {
+        // Wild Pokémon of any level will always have the base amount of experience required to reach that level when caught, as will Pokémon hatched from Eggs.
+        "experienceStarting": function (NumberMaker, constants, equations, title, level) {
             var reference = constants.pokemon[title];
 
             // TODO: remove defaulting to mediumFast
@@ -543,10 +532,10 @@ FullScreenPokemon.prototype.settings.math = {
          *     table = [],
          *     indices = {},
          *     values = {
-         *         "0�": 0.0,
-         *         "��": .5,
-         *         "1�": 1.0,
-         *         "2�": 2.0
+         *         "0×": 0.0,
+         *         "½×": .5,
+         *         "1×": 1.0,
+         *         "2×": 2.0
          *     },
          *     output = { 
          *         "names": names, 
@@ -634,1332 +623,14803 @@ FullScreenPokemon.prototype.settings.math = {
          */
         "pokemon": {
             "Abra": {
-                "types": ["Psychic"],
-                "HP": 25,
-                "Attack": 20,
-                "Defense": 15,
-                "Special": 105,
-                "Speed": 90
-            },
-            "Aerodactyl": {
-                "types": ["Flying", "Rock"],
-                "HP": 80,
-                "Attack": 105,
-                "Defense": 65,
-                "Special": 60,
-                "Speed": 130
-            },
-            "Alakazam": {
-                "types": ["Psychic"],
-                "HP": 55,
-                "Attack": 50,
-                "Defense": 45,
-                "Special": 135,
-                "Speed": 120
-            },
-            "Arbok": {
-                "types": ["Poison"],
-                "HP": 60,
-                "Attack": 85,
-                "Defense": 69,
-                "Special": 65,
-                "Speed": 80
-            },
-            "Arcanine": {
-                "types": ["Fire"],
-                "HP": 90,
-                "Attack": 110,
-                "Defense": 80,
-                "Special": 80,
-                "Speed": 95
-            },
-            "Articuno": {
-                "types": ["Flying", "Ice"],
-                "HP": 90,
-                "Attack": 85,
-                "Defense": 100,
-                "Special": 125,
-                "Speed": 85
-            },
-            "Beedrill": {
-                "types": ["Bug", "Poison"],
-                "HP": 65,
-                "Attack": 80,
-                "Defense": 40,
-                "Special": 45,
-                "Speed": 75
-            },
-            "Bellsprout": {
-                "types": ["Grass", "Poison"],
-                "HP": 50,
-                "Attack": 75,
-                "Defense": 35,
-                "Special": 70,
-                "Speed": 40
-            },
-            "Blastoise": {
-                "types": ["Water"],
-                "HP": 79,
-                "Attack": 83,
-                "Defense": 100,
-                "Special": 85,
-                "Speed": 78
-            },
-            "Bulbasaur": {
-                "types": ["Grass", "Poison"],
-                "HP": 45,
-                "Attack": 49,
-                "Defense": 49,
-                "Special": 65,
-                "Speed": 45,
-                "moves": {
-                    "natural": [
-                        {
-                            "level": 0,
-                            "Move": "Tackle"
-                        }, {
-                            "level": 0,
-                            "Move": "Growl"
-                        }, {
-                            "level": 7,
-                            "Move": "Leech Seed"
-                        }, {
-                            "level": 13,
-                            "Move": "Vine Whip"
-                        }, {
-                            "level": 20,
-                            "Move": "PoisonPowder"
-                        }, {
-                            "level": 27,
-                            "Move": "Razor Leaf"
-                        }, {
-                            "level": 34,
-                            "Move": "Grown"
-                        }, {
-                            "level": 41,
-                            "Move": "Sleep Powder"
-                        }, {
-                            "level": 48,
-                            "Move": "SolarBeam"
-                        }
-                    ]
-                }
-            },
-            "Butterfree": {
-                "types": ["Bug", "Flying"],
-                "HP": 60,
-                "Attack": 45,
-                "Defense": 50,
-                "Special": 80,
-                "Speed": 70
-            },
-            "Caterpie": {
-                "types": ["Bug"],
-                "HP": 45,
-                "Attack": 30,
-                "Defense": 35,
-                "Special": 20,
-                "Speed": 45
-            },
-            "Chansey": {
-                "types": ["Normal"],
-                "HP": 250,
-                "Attack": 5,
-                "Defense": 5,
-                "Special": 105,
-                "Speed": 50
-            },
-            "Charizard": {
-                "types": ["Fire", "Flying"],
-                "HP": 78,
-                "Attack": 84,
-                "Defense": 78,
-                "Special": 85,
-                "Speed": 100
-            },
-            "Charmander": {
-                "types": ["Fire"],
-                "HP": 39,
-                "Attack": 52,
-                "Defense": 43,
-                "Special": 50,
-                "Speed": 65
-            },
-            "Charmeleon": {
-                "types": ["Fire"],
-                "HP": 58,
-                "Attack": 64,
-                "Defense": 58,
-                "Special": 65,
-                "Speed": 80
-            },
-            "Clefable": {
-                "types": ["Normal"],
-                "HP": 95,
-                "Attack": 70,
-                "Defense": 73,
-                "Special": 85,
-                "Speed": 60
-            },
-            "Clefairy": {
-                "types": ["Normal"],
-                "HP": 70,
-                "Attack": 45,
-                "Defense": 48,
-                "Special": 60,
-                "Speed": 35
-            },
-            "Cloyster": {
-                "types": ["Ice", "Water"],
-                "HP": 50,
-                "Attack": 95,
-                "Defense": 180,
-                "Special": 85,
-                "Speed": 70
-            },
-            "Cubone": {
-                "types": ["Ground"],
-                "HP": 50,
-                "Attack": 50,
-                "Defense": 95,
-                "Special": 40,
-                "Speed": 35
-            },
-            "Dewgong": {
-                "types": ["Ice", "Water"],
-                "HP": 90,
-                "Attack": 70,
-                "Defense": 80,
-                "Special": 95,
-                "Speed": 70
-            },
-            "Diglett": {
-                "types": ["Ground"],
-                "HP": 10,
-                "Attack": 55,
-                "Defense": 25,
-                "Special": 45,
-                "Speed": 95
-            },
-            "Ditto": {
-                "types": ["Normal"],
-                "HP": 48,
-                "Attack": 48,
-                "Defense": 48,
-                "Special": 48,
-                "Speed": 48
-            },
-            "Dodrio": {
-                "types": ["Flying", "Normal"],
-                "HP": 60,
-                "Attack": 110,
-                "Defense": 70,
-                "Special": 60,
-                "Speed": 100
-            },
-            "Doduo": {
-                "types": ["Flying", "Normal"],
-                "HP": 35,
-                "Attack": 85,
-                "Defense": 45,
-                "Special": 35,
-                "Speed": 75
-            },
-            "Dragonair": {
-                "types": ["Dragon"],
-                "HP": 61,
-                "Attack": 84,
-                "Defense": 65,
-                "Special": 70,
-                "Speed": 70
-            },
-            "Dragonite": {
-                "types": ["Dragon", "Flying"],
-                "HP": 91,
-                "Attack": 134,
-                "Defense": 95,
-                "Special": 100,
-                "Speed": 80
-            },
-            "Dratini": {
-                "types": ["Dragon"],
-                "HP": 41,
-                "Attack": 64,
-                "Defense": 45,
-                "Special": 50,
-                "Speed": 50
-            },
-            "Drowzee": {
-                "types": ["Psychic"],
-                "HP": 60,
-                "Attack": 48,
-                "Defense": 45,
-                "Special": 90,
-                "Speed": 42
-            },
-            "Dugtrio": {
-                "types": ["Ground"],
-                "HP": 35,
-                "Attack": 80,
-                "Defense": 50,
-                "Special": 70,
-                "Speed": 120
-            },
-            "Eevee": {
-                "types": ["Normal"],
-                "HP": 55,
-                "Attack": 55,
-                "Defense": 50,
-                "Special": 65,
-                "Speed": 55
-            },
-            "Ekans": {
-                "types": ["Poison"],
-                "HP": 35,
-                "Attack": 60,
-                "Defense": 44,
-                "Special": 40,
-                "Speed": 55
-            },
-            "Electabuzz": {
-                "types": ["Electric"],
-                "HP": 65,
-                "Attack": 83,
-                "Defense": 57,
-                "Special": 85,
-                "Speed": 105
-            },
-            "Electrode": {
-                "types": ["Electric"],
-                "HP": 60,
-                "Attack": 50,
-                "Defense": 70,
-                "Special": 80,
-                "Speed": 140
-            },
-            "Exeggcute": {
-                "types": ["Grass", "Psychic"],
-                "HP": 60,
-                "Attack": 40,
-                "Defense": 80,
-                "Special": 60,
-                "Speed": 40
-            },
-            "Exeggutor": {
-                "types": ["Grass", "Psychic"],
-                "HP": 95,
-                "Attack": 95,
-                "Defense": 85,
-                "Special": 125,
-                "Speed": 55
-            },
-            "Farfetch'd": {
-                "types": ["Flying", "Normal"],
-                "HP": 52,
-                "Attack": 65,
-                "Defense": 55,
-                "Special": 58,
-                "Speed": 60
-            },
-            "Fearow": {
-                "types": ["Flying", "Normal"],
-                "HP": 65,
-                "Attack": 90,
-                "Defense": 65,
-                "Special": 61,
-                "Speed": 100
-            },
-            "Flareon": {
-                "types": ["Fire"],
-                "HP": 65,
-                "Attack": 130,
-                "Defense": 60,
-                "Special": 110,
-                "Speed": 65
-            },
-            "Gastly": {
-                "types": ["Ghost", "Poison"],
-                "HP": 30,
-                "Attack": 35,
-                "Defense": 30,
-                "Special": 100,
-                "Speed": 80
-            },
-            "Gengar": {
-                "types": ["Ghost", "Poison"],
-                "HP": 60,
-                "Attack": 65,
-                "Defense": 60,
-                "Special": 130,
-                "Speed": 110
-            },
-            "Geodude": {
-                "types": ["Ground", "Rock"],
-                "HP": 40,
-                "Attack": 80,
-                "Defense": 100,
-                "Special": 30,
-                "Speed": 20
-            },
-            "Gloom": {
-                "types": ["Grass", "Poison"],
-                "HP": 60,
-                "Attack": 65,
-                "Defense": 70,
-                "Special": 85,
-                "Speed": 40
-            },
-            "Golbat": {
-                "types": ["Flying", "Poison"],
-                "HP": 75,
-                "Attack": 80,
-                "Defense": 70,
-                "Special": 75,
-                "Speed": 90
-            },
-            "Goldeen": {
-                "types": ["Water"],
-                "HP": 45,
-                "Attack": 67,
-                "Defense": 60,
-                "Special": 50,
-                "Speed": 63
-            },
-            "Golduck": {
-                "types": ["Water"],
-                "HP": 80,
-                "Attack": 82,
-                "Defense": 78,
-                "Special": 80,
-                "Speed": 85
-            },
-            "Golem": {
-                "types": ["Ground", "Rock"],
-                "HP": 80,
-                "Attack": 110,
-                "Defense": 130,
-                "Special": 55,
-                "Speed": 45
-            },
-            "Graveler": {
-                "types": ["Ground", "Rock"],
-                "HP": 55,
-                "Attack": 95,
-                "Defense": 115,
-                "Special": 45,
-                "Speed": 35
-            },
-            "Grimer": {
-                "types": ["Poison"],
-                "HP": 80,
-                "Attack": 80,
-                "Defense": 50,
-                "Special": 40,
-                "Speed": 25
-            },
-            "Growlithe": {
-                "types": ["Fire"],
-                "HP": 55,
-                "Attack": 70,
-                "Defense": 45,
-                "Special": 50,
-                "Speed": 60
-            },
-            "Gyarados": {
-                "types": ["Flying", "Water"],
-                "HP": 95,
-                "Attack": 125,
-                "Defense": 79,
-                "Special": 100,
-                "Speed": 81
-            },
-            "Haunter": {
-                "types": ["Ghost", "Poison"],
-                "HP": 45,
-                "Attack": 50,
-                "Defense": 45,
-                "Special": 115,
-                "Speed": 95
-            },
-            "Hitmonchan": {
-                "types": ["Fighting"],
-                "HP": 50,
-                "Attack": 105,
-                "Defense": 79,
-                "Special": 35,
-                "Speed": 76
-            },
-            "Hitmonlee": {
-                "types": ["Fighting"],
-                "HP": 50,
-                "Attack": 120,
-                "Defense": 53,
-                "Special": 35,
-                "Speed": 87
-            },
-            "Horsea": {
-                "types": ["Water"],
-                "HP": 30,
-                "Attack": 40,
-                "Defense": 70,
-                "Special": 70,
-                "Speed": 60
-            },
-            "Hypno": {
-                "types": ["Psychic"],
-                "HP": 85,
-                "Attack": 73,
-                "Defense": 70,
-                "Special": 115,
-                "Speed": 67
-            },
-            "Ivysaur": {
-                "types": ["Grass", "Poison"],
-                "HP": 60,
-                "Attack": 62,
-                "Defense": 63,
-                "Special": 80,
-                "Speed": 60
-            },
-            "Jigglypuff": {
-                "types": ["Normal"],
-                "HP": 115,
-                "Attack": 45,
-                "Defense": 20,
-                "Special": 25,
-                "Speed": 20
-            },
-            "Jolteon": {
-                "types": ["Electric"],
-                "HP": 65,
-                "Attack": 65,
-                "Defense": 60,
-                "Special": 110,
-                "Speed": 130
-            },
-            "Jynx": {
-                "types": ["Ice", "Psychic"],
-                "HP": 65,
-                "Attack": 50,
-                "Defense": 35,
-                "Special": 95,
-                "Speed": 95
-            },
-            "Kabuto": {
-                "types": ["Rock", "Water"],
-                "HP": 30,
-                "Attack": 80,
-                "Defense": 90,
-                "Special": 45,
-                "Speed": 55
-            },
-            "Kabutops": {
-                "types": ["Rock", "Water"],
-                "HP": 60,
-                "Attack": 115,
-                "Defense": 105,
-                "Special": 70,
-                "Speed": 80
-            },
-            "Kadabra": {
-                "types": ["Psychic"],
-                "HP": 40,
-                "Attack": 35,
-                "Defense": 30,
-                "Special": 120,
-                "Speed": 105
-            },
-            "Kakuna": {
-                "types": ["Bug", "Poison"],
-                "HP": 45,
-                "Attack": 25,
-                "Defense": 50,
-                "Special": 25,
-                "Speed": 35
-            },
-            "Kangaskhan": {
-                "types": ["Normal"],
-                "HP": 105,
-                "Attack": 95,
-                "Defense": 80,
-                "Special": 40,
-                "Speed": 90
-            },
-            "Kingler": {
-                "types": ["Water"],
-                "HP": 55,
-                "Attack": 130,
-                "Defense": 115,
-                "Special": 50,
-                "Speed": 75
-            },
-            "Koffing": {
-                "types": ["Poison"],
-                "HP": 40,
-                "Attack": 65,
-                "Defense": 95,
-                "Special": 60,
-                "Speed": 35
-            },
-            "Krabby": {
-                "types": ["Water"],
-                "HP": 30,
-                "Attack": 105,
-                "Defense": 90,
-                "Special": 25,
-                "Speed": 50
-            },
-            "Lapras": {
-                "types": ["Ice", "Water"],
-                "HP": 130,
-                "Attack": 85,
-                "Defense": 80,
-                "Special": 95,
-                "Speed": 60
-            },
-            "Lickitung": {
-                "types": ["Normal"],
-                "HP": 90,
-                "Attack": 55,
-                "Defense": 75,
-                "Special": 60,
-                "Speed": 30
-            },
-            "Machamp": {
-                "types": ["Fighting"],
-                "HP": 90,
-                "Attack": 130,
-                "Defense": 80,
-                "Special": 65,
-                "Speed": 55
-            },
-            "Machoke": {
-                "types": ["Fighting"],
-                "HP": 80,
-                "Attack": 100,
-                "Defense": 70,
-                "Special": 50,
-                "Speed": 45
-            },
-            "Machop": {
-                "types": ["Fighting"],
-                "HP": 70,
-                "Attack": 80,
-                "Defense": 50,
-                "Special": 35,
-                "Speed": 35
-            },
-            "Magikarp": {
-                "types": ["Water"],
-                "HP": 20,
-                "Attack": 10,
-                "Defense": 55,
-                "Special": 20,
-                "Speed": 80
-            },
-            "Magmar": {
-                "types": ["Fire"],
-                "HP": 65,
-                "Attack": 95,
-                "Defense": 57,
-                "Special": 85,
-                "Speed": 93
-            },
-            "Magnemite": {
-                "types": ["Electric"],
-                "HP": 25,
-                "Attack": 35,
-                "Defense": 70,
-                "Special": 95,
-                "Speed": 45
-            },
-            "Magneton": {
-                "types": ["Electric"],
-                "HP": 50,
-                "Attack": 60,
-                "Defense": 95,
-                "Special": 120,
-                "Speed": 70
-            },
-            "Mankey": {
-                "types": ["Fighting"],
-                "HP": 40,
-                "Attack": 80,
-                "Defense": 35,
-                "Special": 35,
-                "Speed": 70
-            },
-            "Marowak": {
-                "types": ["Ground"],
-                "HP": 60,
-                "Attack": 80,
-                "Defense": 110,
-                "Special": 50,
-                "Speed": 45
-            },
-            "Meowth": {
-                "types": ["Normal"],
-                "HP": 40,
-                "Attack": 45,
-                "Defense": 35,
-                "Special": 40,
-                "Speed": 90
-            },
-            "Metapod": {
-                "types": ["Bug"],
-                "HP": 50,
-                "Attack": 20,
-                "Defense": 55,
-                "Special": 25,
-                "Speed": 30
-            },
-            "Mew": {
-                "types": ["Psychic"],
-                "HP": 100,
-                "Attack": 100,
-                "Defense": 100,
-                "Special": 100,
-                "Speed": 100
-            },
-            "Mewtwo": {
-                "types": ["Psychic"],
-                "HP": 106,
-                "Attack": 110,
-                "Defense": 90,
-                "Special": 154,
-                "Speed": 130
-            },
-            "Moltres": {
-                "types": ["Fire", "Flying"],
-                "HP": 90,
-                "Attack": 100,
-                "Defense": 90,
-                "Special": 125,
-                "Speed": 90
-            },
-            "Mr. Mime": {
-                "types": ["Psychic"],
-                "HP": 40,
-                "Attack": 45,
-                "Defense": 65,
-                "Special": 100,
-                "Speed": 90
-            },
-            "Muk": {
-                "types": ["Poison"],
-                "HP": 105,
-                "Attack": 105,
-                "Defense": 75,
-                "Special": 65,
-                "Speed": 50
-            },
-            "Nidoking": {
-                "types": ["Ground", "Poison"],
-                "HP": 81,
-                "Attack": 92,
-                "Defense": 77,
-                "Special": 75,
-                "Speed": 85
-            },
-            "Nidoqueen": {
-                "types": ["Ground", "Poison"],
-                "HP": 90,
-                "Attack": 82,
-                "Defense": 87,
-                "Special": 75,
-                "Speed": 76
-            },
-            "Nidoran-F": {
-                "types": ["Poison"],
-                "HP": 55,
-                "Attack": 47,
-                "Defense": 52,
-                "Special": 40,
-                "Speed": 41
-            },
-            "Nidoran-M": {
-                "types": ["Poison"],
-                "HP": 46,
-                "Attack": 57,
-                "Defense": 40,
-                "Special": 40,
-                "Speed": 50
-            },
-            "Nidorina": {
-                "types": ["Poison"],
-                "HP": 70,
-                "Attack": 62,
-                "Defense": 67,
-                "Special": 55,
-                "Speed": 56
-            },
-            "Nidorino": {
-                "types": ["Poison"],
-                "HP": 61,
-                "Attack": 72,
-                "Defense": 57,
-                "Special": 55,
-                "Speed": 65
-            },
-            "Ninetales": {
-                "types": ["Fire"],
-                "HP": 73,
-                "Attack": 76,
-                "Defense": 75,
-                "Special": 100,
-                "Speed": 100
-            },
-            "Oddish": {
-                "types": ["Grass", "Poison"],
-                "HP": 45,
-                "Attack": 50,
-                "Defense": 55,
-                "Special": 75,
-                "Speed": 30
-            },
-            "Omanyte": {
-                "types": ["Rock", "Water"],
-                "HP": 35,
-                "Attack": 40,
-                "Defense": 100,
-                "Special": 90,
-                "Speed": 35
-            },
-            "Omastar": {
-                "types": ["Rock", "Water"],
-                "HP": 70,
-                "Attack": 60,
-                "Defense": 125,
-                "Special": 115,
-                "Speed": 55
-            },
-            "Onix": {
-                "types": ["Ground", "Rock"],
-                "HP": 35,
-                "Attack": 45,
-                "Defense": 160,
-                "Special": 30,
-                "Speed": 70
-            },
-            "Paras": {
-                "types": ["Bug", "Grass"],
-                "HP": 35,
-                "Attack": 70,
-                "Defense": 55,
-                "Special": 55,
-                "Speed": 25
-            },
-            "Parasect": {
-                "types": ["Bug", "Grass"],
-                "HP": 60,
-                "Attack": 95,
-                "Defense": 80,
-                "Special": 80,
-                "Speed": 30
-            },
-            "Persian": {
-                "types": ["Normal"],
-                "HP": 65,
-                "Attack": 70,
-                "Defense": 60,
-                "Special": 65,
-                "Speed": 115
-            },
-            "Pidgeot": {
-                "types": ["Flying", "Normal"],
-                "HP": 83,
-                "Attack": 80,
-                "Defense": 75,
-                "Special": 70,
-                "Speed": 91
-            },
-            "Pidgeotto": {
-                "types": ["Flying", "Normal"],
-                "HP": 63,
-                "Attack": 60,
-                "Defense": 55,
-                "Special": 50,
-                "Speed": 71
-            },
-            "Pidgey": {
-                "types": ["Flying", "Normal"],
-                "HP": 40,
-                "Attack": 45,
-                "Defense": 40,
-                "Special": 35,
-                "Speed": 56,
-                "moves": {
-                    "natural": [
-                        {
-                            "level": 0,
-                            "Move": "Gust"
-                        }, {
-                            "level": 5,
-                            "Move": "Sand Attack"
-                        }, {
-                            "level": 12,
-                            "Move": "Quick Attack"
-                        }, {
-                            "level": 19,
-                            "Move": "Whirlwind"
-                        }, {
-                            "level": 28,
-                            "Move": "Wing Attack"
-                        }, {
-                            "level": 36,
-                            "Move": "Agility"
-                        }, {
-                            "level": 44,
-                            "Move": "Mirror Move"
-                        }
-                    ]
-                }
-            },
-            "Pikachu": {
-                "types": ["Electric"],
-                "HP": 35,
-                "Attack": 55,
-                "Defense": 30,
-                "Special": 50,
-                "Speed": 90
-            },
-            "Pinsir": {
-                "types": ["Bug"],
-                "HP": 65,
-                "Attack": 125,
-                "Defense": 100,
-                "Special": 55,
-                "Speed": 85
-            },
-            "Poliwag": {
-                "types": ["Water"],
-                "HP": 40,
-                "Attack": 50,
-                "Defense": 40,
-                "Special": 40,
-                "Speed": 90
-            },
-            "Poliwhirl": {
-                "types": ["Water"],
-                "HP": 65,
-                "Attack": 65,
-                "Defense": 65,
-                "Special": 50,
-                "Speed": 90
-            },
-            "Poliwrath": {
-                "types": ["Fighting", "Water"],
-                "HP": 90,
-                "Attack": 85,
-                "Defense": 95,
-                "Special": 70,
-                "Speed": 70
-            },
-            "Ponyta": {
-                "types": ["Fire"],
-                "HP": 50,
-                "Attack": 85,
-                "Defense": 55,
-                "Special": 65,
-                "Speed": 90
-            },
-            "Porygon": {
-                "types": ["Normal"],
-                "HP": 65,
-                "Attack": 60,
-                "Defense": 70,
-                "Special": 75,
-                "Speed": 40
-            },
-            "Primeape": {
-                "types": ["Fighting"],
-                "HP": 65,
-                "Attack": 105,
-                "Defense": 60,
-                "Special": 60,
-                "Speed": 95
-            },
-            "Psyduck": {
-                "types": ["Water"],
-                "HP": 50,
-                "Attack": 52,
-                "Defense": 48,
-                "Special": 50,
-                "Speed": 55
-            },
-            "Raichu": {
-                "types": ["Electric"],
-                "HP": 60,
-                "Attack": 90,
-                "Defense": 55,
-                "Special": 90,
-                "Speed": 100
-            },
-            "Rapidash": {
-                "types": ["Fire"],
-                "HP": 65,
-                "Attack": 100,
-                "Defense": 70,
-                "Special": 80,
-                "Speed": 105
-            },
-            "Raticate": {
-                "types": ["Normal"],
-                "HP": 55,
-                "Attack": 81,
-                "Defense": 60,
-                "Special": 50,
-                "Speed": 97
-            },
-            "Rattata": {
-                "types": ["Normal"],
-                "HP": 30,
-                "Attack": 56,
-                "Defense": 35,
-                "Special": 25,
-                "Speed": 72,
-                "moves": {
-                    "natural": [
-                        {
-                            "level": 0,
-                            "Move": "Tackle"
-                        }, {
-                            "level": 0,
-                            "Move": "Tail Whip"
-                        }, {
-                            "level": 7,
-                            "Move": "Quick Attack"
-                        }, {
-                            "level": 14,
-                            "Move": "Hyper Fang"
-                        }, {
-                            "level": 23,
-                            "Move": "Focus Energy"
-                        }, {
-                            "level": 34,
-                            "Move": "Super Fang"
-                        },
-                    ]
-                }
-            },
-            "Rhydon": {
-                "types": ["Ground", "Rock"],
-                "HP": 105,
-                "Attack": 130,
-                "Defense": 120,
-                "Special": 45,
-                "Speed": 40
-            },
-            "Rhyhorn": {
-                "types": ["Ground", "Rock"],
-                "HP": 80,
-                "Attack": 85,
-                "Defense": 95,
-                "Special": 30,
-                "Speed": 25
-            },
-            "Sandshrew": {
-                "types": ["Ground"],
-                "HP": 50,
-                "Attack": 75,
-                "Defense": 85,
-                "Special": 30,
-                "Speed": 40
-            },
-            "Sandslash": {
-                "types": ["Ground"],
-                "HP": 75,
-                "Attack": 100,
-                "Defense": 110,
-                "Special": 55,
-                "Speed": 65
-            },
-            "Scyther": {
-                "types": ["Bug", "Flying"],
-                "HP": 70,
-                "Attack": 110,
-                "Defense": 80,
-                "Special": 55,
-                "Speed": 105
-            },
-            "Seadra": {
-                "types": ["Water"],
-                "HP": 55,
-                "Attack": 65,
-                "Defense": 95,
-                "Special": 95,
-                "Speed": 85
-            },
-            "Seaking": {
-                "types": ["Water"],
-                "HP": 80,
-                "Attack": 92,
-                "Defense": 65,
-                "Special": 80,
-                "Speed": 68
-            },
-            "Seel": {
-                "types": ["Water"],
-                "HP": 65,
-                "Attack": 45,
-                "Defense": 55,
-                "Special": 70,
-                "Speed": 45
-            },
-            "Shellder": {
-                "types": ["Water"],
-                "HP": 30,
-                "Attack": 65,
-                "Defense": 100,
-                "Special": 45,
-                "Speed": 40
-            },
-            "Slowbro": {
-                "types": ["Psychic", "Water"],
-                "HP": 95,
-                "Attack": 75,
-                "Defense": 110,
-                "Special": 80,
-                "Speed": 30
-            },
-            "Slowpoke": {
-                "types": ["Psychic", "Water"],
-                "HP": 90,
-                "Attack": 65,
-                "Defense": 65,
-                "Special": 40,
-                "Speed": 15
-            },
-            "Snorlax": {
-                "types": ["Normal"],
-                "HP": 160,
-                "Attack": 110,
-                "Defense": 65,
-                "Special": 65,
-                "Speed": 30
-            },
-            "Spearow": {
-                "types": ["Flying", "Normal"],
-                "HP": 40,
-                "Attack": 60,
-                "Defense": 30,
-                "Special": 31,
-                "Speed": 70
-            },
-            "Squirtle": {
-                "label": "TINYTURTLE",
-                "sprite": "Water",
-                "info": [
-                    "After birth, its back swells and hardens into a",
-                    "shell. Powerfully sprays foam out of its mouth."
-                ],
-                "number": 7,
-                "height": ["1", "08"],
-                "weight": "20.0",
-                "types": ["Water"],
-                "HP": 44,
-                "Attack": 48,
-                "Defense": 65,
-                "Special": 50,
-                "Speed": 43,
-                "moves": {
-                    "natural": [
-                        {
-                            "level": 0,
-                            "Move": "Tackle"
-                        }, {
-                            "level": 0,
-                            "Move": "Tail Whip"
-                        }, {
-                            "level": 8,
-                            "Move": "Bubble"
-                        }, {
-                            "level": 15,
-                            "Move": "Water Gun"
-                        }, {
-                            "level": 22,
-                            "Move": "Bite"
-                        }, {
-                            "level": 28,
-                            "Move": "Withdraw"
-                        }, {
-                            "level": 35,
-                            "Move": "Skull Bash"
-                        }, {
-                            "level": 42,
-                            "Move": "Hydro Pump"
-                        }
-                    ]
-                }
-            },
-            "Starmie": {
-                "types": ["Psychic", "Water"],
-                "HP": 60,
-                "Attack": 75,
-                "Defense": 85,
-                "Special": 100,
-                "Speed": 115
-            },
-            "Staryu": {
-                "types": ["Water"],
-                "HP": 30,
-                "Attack": 45,
-                "Defense": 55,
-                "Special": 70,
-                "Speed": 85
-            },
-            "Tangela": {
-                "types": ["Grass"],
-                "HP": 65,
-                "Attack": 55,
-                "Defense": 115,
-                "Special": 100,
-                "Speed": 60
-            },
-            "Tauros": {
-                "types": ["Normal"],
-                "HP": 75,
-                "Attack": 100,
-                "Defense": 95,
-                "Special": 70,
-                "Speed": 110
-            },
-            "Tentacool": {
-                "types": ["Poison", "Water"],
-                "HP": 40,
-                "Attack": 40,
-                "Defense": 35,
-                "Special": 100,
-                "Speed": 70
-            },
-            "Tentacruel": {
-                "types": ["Poison", "Water"],
-                "HP": 80,
-                "Attack": 70,
-                "Defense": 65,
-                "Special": 120,
-                "Speed": 100
-            },
-            "Vaporeon": {
-                "types": ["Water"],
-                "HP": 130,
-                "Attack": 65,
-                "Defense": 60,
-                "Special": 110,
-                "Speed": 65
-            },
-            "Venomoth": {
-                "types": ["Bug", "Poison"],
-                "HP": 70,
-                "Attack": 65,
-                "Defense": 60,
-                "Special": 90,
-                "Speed": 90
-            },
-            "Venonat": {
-                "types": ["Bug", "Poison"],
-                "HP": 60,
-                "Attack": 55,
-                "Defense": 50,
-                "Special": 40,
-                "Speed": 45
-            },
-            "Venusaur": {
-                "types": ["Grass", "Poison"],
-                "HP": 80,
-                "Attack": 82,
-                "Defense": 83,
-                "Special": 100,
-                "Speed": 80
-            },
-            "Victreebel": {
-                "types": ["Grass", "Poison"],
-                "HP": 80,
-                "Attack": 105,
-                "Defense": 65,
-                "Special": 100,
-                "Speed": 70
-            },
-            "Vileplume": {
-                "types": ["Grass", "Poison"],
-                "HP": 75,
-                "Attack": 80,
-                "Defense": 85,
-                "Special": 100,
-                "Speed": 50
-            },
-            "Voltorb": {
-                "types": ["Electric"],
-                "HP": 40,
-                "Attack": 30,
-                "Defense": 50,
-                "Special": 55,
-                "Speed": 100
-            },
-            "Vulpix": {
-                "types": ["Fire"],
-                "HP": 38,
-                "Attack": 41,
-                "Defense": 40,
-                "Special": 65,
-                "Speed": 65
-            },
-            "Wartortle": {
-                "types": ["Water"],
-                "HP": 59,
-                "Attack": 63,
-                "Defense": 80,
-                "Special": 65,
-                "Speed": 58
-            },
-            "Weedle": {
-                "types": ["Bug", "Poison"],
-                "HP": 40,
-                "Attack": 35,
-                "Defense": 30,
-                "Special": 20,
-                "Speed": 50
-            },
-            "Weepinbell": {
-                "types": ["Grass", "Poison"],
-                "HP": 65,
-                "Attack": 90,
-                "Defense": 50,
-                "Special": 85,
-                "Speed": 55
-            },
-            "Weezing": {
-                "types": ["Poison"],
-                "HP": 65,
-                "Attack": 90,
-                "Defense": 120,
-                "Special": 85,
-                "Speed": 60
-            },
-            "Wigglytuff": {
-                "types": ["Normal"],
-                "HP": 140,
-                "Attack": 70,
-                "Defense": 45,
-                "Special": 50,
-                "Speed": 45
-            },
-            "Zapdos": {
-                "types": ["Electric", "Flying"],
-                "HP": 90,
-                "Attack": 90,
-                "Defense": 85,
-                "Special": 125,
-                "Speed": 100
-            },
-            "Zubat": {
-                "types": ["Flying", "Poison"],
-                "HP": 40,
-                "Attack": 45,
-                "Defense": 35,
-                "Special": 40,
-                "Speed": 55
-            }
+    "label": "Psi",
+    "sprite": "water",
+    "info": [
+        "Using its ability to read minds, it will identify impending danger and TELEPORT to safety."
+    ],
+    "evolvesInto": "Kadabra",
+    "evolvesVia": "Level 16",
+    "number": 063,
+    "height": ["2", "11"],
+    "weight": 43,
+    "types": ["Psychic"],
+    "HP": 25,
+    "Attack": 20,
+    "Defense": 15,
+    "Special": 105,
+    "Speed": 90,
+    "moves": {
+        "natural": [{
+            "Move": "Teleport",
+            "level": 1
+        }],
+        "hm": [{
+            "Move": "Flash",
+            "level": 5
+        }],
+        "tm": [{
+            "Move": "Mega Punch",
+            "level": 1
+        }, {
+            "Move": "Mega Kick",
+            "level": 5
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Counter",
+            "level": 18
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Psychic",
+            "level": 29
+        }, {
+            "Move": "Teleport",
+            "level": 30
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Metronome",
+            "level": 35
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Thunder Wave",
+            "level": 45
+        }, {
+            "Move": "Psywave",
+            "level": 46
+        }, {
+            "Move": "Tri Attack",
+            "level": 49
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Aerodactyl": {
+    "label": "Fossil",
+    "sprite": "water",
+    "info": [
+        "A ferocious, prehistoric POKÃ©MON that goes for the enemy's throat with its serrated saw-like fangs."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 142,
+    "height": ["5", "11"],
+    "weight": 130.1,
+    "types": ["Rock", "Flying"],
+    "HP": 80,
+    "Attack": 105,
+    "Defense": 65,
+    "Special": 60,
+    "Speed": 130,
+    "moves": {
+        "natural": [{
+            "Move": "Agility",
+            "level": 1
+        }, {
+            "Move": "Wing Attack",
+            "level": 1
+        }, {
+            "Move": "Supersonic",
+            "level": 33
+        }, {
+            "Move": "Bite",
+            "level": 38
+        }, {
+            "Move": "Take Down",
+            "level": 45
+        }, {
+            "Move": "Hyper Beam",
+            "level": 54
+        }],
+        "hm": [{
+            "Move": "Fly",
+            "level": 2
+        }],
+        "tm": [{
+            "Move": "Razor Wind",
+            "level": 2
+        }, {
+            "Move": "Whirlwind",
+            "level": 4
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Dragon Rage",
+            "level": 23
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Fire Blast",
+            "level": 38
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Sky Attack",
+            "level": 43
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Alakazam": {
+    "label": "Psi",
+    "sprite": "water",
+    "info": [
+        "Its brain can outperform a supercomputer. Its intelligence quotient is said to be 5,000."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 065,
+    "height": ["4", "11"],
+    "weight": 105.8,
+    "types": ["Psychic"],
+    "HP": 55,
+    "Attack": 50,
+    "Defense": 45,
+    "Special": 135,
+    "Speed": 120,
+    "moves": {
+        "natural": [{
+            "Move": "Confusion",
+            "level": 1
+        }, {
+            "Move": "Disable",
+            "level": 1
+        }, {
+            "Move": "Teleport",
+            "level": 1
+        }, {
+            "Move": "Confusion",
+            "level": 16
+        }, {
+            "Move": "Disable",
+            "level": 20
+        }, {
+            "Move": "Psybeam",
+            "level": 27
+        }, {
+            "Move": "Recover",
+            "level": 31
+        }, {
+            "Move": "Psychic",
+            "level": 38
+        }, {
+            "Move": "Reflect",
+            "level": 42
+        }],
+        "hm": [{
+            "Move": "Flash",
+            "level": 5
+        }],
+        "tm": [{
+            "Move": "Mega Punch",
+            "level": 1
+        }, {
+            "Move": "Mega Kick",
+            "level": 5
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Counter",
+            "level": 18
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Dig",
+            "level": 28
+        }, {
+            "Move": "Psychic",
+            "level": 29
+        }, {
+            "Move": "Teleport",
+            "level": 30
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Metronome",
+            "level": 35
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Thunder Wave",
+            "level": 45
+        }, {
+            "Move": "Psywave",
+            "level": 46
+        }, {
+            "Move": "Tri Attack",
+            "level": 49
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Arbok": {
+    "label": "Cobra",
+    "sprite": "water",
+    "info": [
+        "It is rumored that the ferocious warning markings on its belly differ from area to area."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 024,
+    "height": ["11", "6"],
+    "weight": 143.3,
+    "types": ["Poison"],
+    "HP": 60,
+    "Attack": 85,
+    "Defense": 69,
+    "Special": 65,
+    "Speed": 80,
+    "moves": {
+        "natural": [{
+            "Move": "Leer",
+            "level": 1
+        }, {
+            "Move": "Poison Sting",
+            "level": 1
+        }, {
+            "Move": "Wrap",
+            "level": 1
+        }, {
+            "Move": "Poison Sting",
+            "level": 10
+        }, {
+            "Move": "Bite",
+            "level": 17
+        }, {
+            "Move": "Glare",
+            "level": 27
+        }, {
+            "Move": "Screech",
+            "level": 36
+        }, {
+            "Move": "Acid",
+            "level": 47
+        }],
+        "hm": [{
+            "Move": "Strength",
+            "level": 4
+        }],
+        "tm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mega Drain",
+            "level": 21
+        }, {
+            "Move": "Earthquake",
+            "level": 26
+        }, {
+            "Move": "Fissure",
+            "level": 27
+        }, {
+            "Move": "Dig",
+            "level": 28
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Rock Slide",
+            "level": 48
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Arcanine": {
+    "label": "Legendary",
+    "sprite": "water",
+    "info": [
+        "A POKÃ©MON that has been admired since the past for its beauty. It runs agilely as if on wings."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 059,
+    "height": ["6", "3"],
+    "weight": 341.7,
+    "types": ["Fire"],
+    "HP": 90,
+    "Attack": 110,
+    "Defense": 80,
+    "Special": 100,
+    "Speed": 95,
+    "moves": {
+        "natural": [{
+            "Move": "Ember",
+            "level": 1
+        }, {
+            "Move": "Leer",
+            "level": 1
+        }, {
+            "Move": "Roar",
+            "level": 1
+        }, {
+            "Move": "Take Down",
+            "level": 1
+        }],
+        "hm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Dragon Rage",
+            "level": 23
+        }, {
+            "Move": "Dig",
+            "level": 28
+        }, {
+            "Move": "Teleport",
+            "level": 30
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Fire Blast",
+            "level": 38
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }],
+        "tm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Dragon Rage",
+            "level": 23
+        }, {
+            "Move": "Dig",
+            "level": 28
+        }, {
+            "Move": "Teleport",
+            "level": 30
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Fire Blast",
+            "level": 38
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Articuno": {
+    "label": "Freeze",
+    "sprite": "water",
+    "info": [
+        "A legendary bird POKÃ©MON that is said to appear to doomed people who are lost in icy mountains."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 144,
+    "height": ["5", "7"],
+    "weight": 122.1,
+    "types": ["Ice", "Flying"],
+    "HP": 90,
+    "Attack": 85,
+    "Defense": 100,
+    "Special": 95,
+    "Speed": 85,
+    "moves": {
+        "natural": [{
+            "Move": "Ice Beam",
+            "level": 1
+        }, {
+            "Move": "Peck",
+            "level": 1
+        }, {
+            "Move": "Blizzard",
+            "level": 51
+        }, {
+            "Move": "Agility",
+            "level": 55
+        }, {
+            "Move": "Mist",
+            "level": 60
+        }],
+        "hm": [{
+            "Move": "Fly",
+            "level": 2
+        }],
+        "tm": [{
+            "Move": "Razor Wind",
+            "level": 2
+        }, {
+            "Move": "Whirlwind",
+            "level": 4
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Bubble Beam",
+            "level": 11
+        }, {
+            "Move": "Water Gun",
+            "level": 12
+        }, {
+            "Move": "Ice Beam",
+            "level": 13
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Sky Attack",
+            "level": 43
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Beedrill": {
+    "label": "Poison Bee",
+    "sprite": "water",
+    "info": [
+        "Flies at high speed and attacks using its large venomous stingers on its forelegs and tail."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 015,
+    "height": ["3", "3"],
+    "weight": 65,
+    "types": ["Bug", "Poison"],
+    "HP": 65,
+    "Attack": 90,
+    "Defense": 40,
+    "Special": 45,
+    "Speed": 75,
+    "moves": {
+        "natural": [{
+            "Move": "Fury Attack",
+            "level": 1
+        }, {
+            "Move": "Fury Attack",
+            "level": 12
+        }, {
+            "Move": "Focus Energy",
+            "level": 16
+        }, {
+            "Move": "Twineedle",
+            "level": 20
+        }, {
+            "Move": "Rage",
+            "level": 25
+        }, {
+            "Move": "Pin Missile",
+            "level": 30
+        }, {
+            "Move": "Agility",
+            "level": 35
+        }],
+        "hm": [{
+            "Move": "Cut",
+            "level": 1
+        }],
+        "tm": [{
+            "Move": "Cut",
+            "level": 1
+        }]
+    }
+}, "Bellsprout": {
+    "label": "Flower",
+    "sprite": "water",
+    "info": [
+        "A carnivorous POKÃ©MON that traps and eats bugs. It uses its root feet to soak up needed moisture."
+    ],
+    "evolvesInto": "Weepinbell",
+    "evolvesVia": "Level 21",
+    "number": 069,
+    "height": ["2", "4"],
+    "weight": 8.8,
+    "types": ["Grass", "Poison"],
+    "HP": 50,
+    "Attack": 75,
+    "Defense": 35,
+    "Special": 70,
+    "Speed": 40,
+    "moves": {
+        "natural": [{
+            "Move": "Growth",
+            "level": 1
+        }, {
+            "Move": "Vine Whip",
+            "level": 1
+        }, {
+            "Move": "Wrap",
+            "level": 13
+        }, {
+            "Move": "Poison Powder",
+            "level": 15
+        }, {
+            "Move": "Sleep Powder",
+            "level": 18
+        }, {
+            "Move": "Stun Spore",
+            "level": 21
+        }, {
+            "Move": "Acid",
+            "level": 26
+        }, {
+            "Move": "Razor Leaf",
+            "level": 33
+        }, {
+            "Move": "Slam",
+            "level": 42
+        }],
+        "hm": [{
+            "Move": "Cut",
+            "level": 1
+        }],
+        "tm": [{
+            "Move": "Swords Dance",
+            "level": 3
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mega Drain",
+            "level": 21
+        }, {
+            "Move": "Solar Beam",
+            "level": 22
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Blastoise": {
+    "label": "Shellfish",
+    "sprite": "water",
+    "info": [
+        "A brutal POKÃ©MON with pressurized water jets on its shell. They are used for high speed tackles."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 009,
+    "height": ["5", "3"],
+    "weight": 188.5,
+    "types": ["Water"],
+    "HP": 79,
+    "Attack": 83,
+    "Defense": 100,
+    "Special": 85,
+    "Speed": 78,
+    "moves": {
+        "natural": [{
+            "Move": "Bubble",
+            "level": 1
+        }, {
+            "Move": "Tackle",
+            "level": 1
+        }, {
+            "Move": "Tail Whip",
+            "level": 1
+        }, {
+            "Move": "Water Gun",
+            "level": 1
+        }, {
+            "Move": "Bubble",
+            "level": 8
+        }, {
+            "Move": "Water Gun",
+            "level": 15
+        }, {
+            "Move": "Bite",
+            "level": 24
+        }, {
+            "Move": "Withdraw",
+            "level": 31
+        }, {
+            "Move": "Skull Bash",
+            "level": 42
+        }, {
+            "Move": "Hydro Pump",
+            "level": 52
+        }],
+        "hm": [{
+            "Move": "Surf",
+            "level": 3
+        }, {
+            "Move": "Strength",
+            "level": 4
+        }],
+        "tm": [{
+            "Move": "Mega Punch",
+            "level": 1
+        }, {
+            "Move": "Mega Kick",
+            "level": 5
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Bubble Beam",
+            "level": 11
+        }, {
+            "Move": "Water Gun",
+            "level": 12
+        }, {
+            "Move": "Ice Beam",
+            "level": 13
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Counter",
+            "level": 18
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Earthquake",
+            "level": 26
+        }, {
+            "Move": "Fissure",
+            "level": 27
+        }, {
+            "Move": "Dig",
+            "level": 28
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Bulbasaur": {
+    "label": "Seed",
+    "sprite": "water",
+    "info": [
+        "A strange seed was planted on its back at birth. The plant sprouts and grows with this POKÃ©MON."
+    ],
+    "evolvesInto": "Ivysaur",
+    "evolvesVia": "Level 16",
+    "number": 001,
+    "height": ["2", "4"],
+    "weight": 15.2,
+    "types": ["Grass", "Poison"],
+    "HP": 45,
+    "Attack": 49,
+    "Defense": 49,
+    "Special": 65,
+    "Speed": 45,
+    "moves": {
+        "natural": [{
+            "Move": "Growl",
+            "level": 1
+        }, {
+            "Move": "Tackle",
+            "level": 1
+        }, {
+            "Move": "Leech Seed",
+            "level": 7
+        }, {
+            "Move": "Vine Whip",
+            "level": 13
+        }, {
+            "Move": "Poison Powder",
+            "level": 20
+        }, {
+            "Move": "Razor Leaf",
+            "level": 27
+        }, {
+            "Move": "Growth",
+            "level": 34
+        }, {
+            "Move": "Sleep Powder",
+            "level": 41
+        }, {
+            "Move": "Solar Beam",
+            "level": 48
+        }],
+        "hm": [{
+            "Move": "Cut",
+            "level": 1
+        }],
+        "tm": [{
+            "Move": "Swords Dance",
+            "level": 3
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mega Drain",
+            "level": 21
+        }, {
+            "Move": "Solar Beam",
+            "level": 22
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Butterfree": {
+    "label": "Butterfly",
+    "sprite": "water",
+    "info": [
+        "In battle, it flaps its wings at high speed to release highly toxic dust into the air."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 012,
+    "height": ["3", "7"],
+    "weight": 70.5,
+    "types": ["Bug", "Flying"],
+    "HP": 60,
+    "Attack": 45,
+    "Defense": 50,
+    "Special": 90,
+    "Speed": 70,
+    "moves": {
+        "natural": [{
+            "Move": "Confusion",
+            "level": 1
+        }, {
+            "Move": "Confusion",
+            "level": 12
+        }, {
+            "Move": "Poison Powder",
+            "level": 15
+        }, {
+            "Move": "Stun Spore",
+            "level": 16
+        }, {
+            "Move": "Sleep Powder",
+            "level": 17
+        }, {
+            "Move": "Supersonic",
+            "level": 21
+        }, {
+            "Move": "Whirlwind",
+            "level": 26
+        }, {
+            "Move": "Psybeam",
+            "level": 32
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Razor Wind",
+            "level": 2
+        }, {
+            "Move": "Whirlwind",
+            "level": 4
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mega Drain",
+            "level": 21
+        }, {
+            "Move": "Solar Beam",
+            "level": 22
+        }, {
+            "Move": "Psychic",
+            "level": 29
+        }, {
+            "Move": "Teleport",
+            "level": 30
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Psywave",
+            "level": 46
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Caterpie": {
+    "label": "Worm",
+    "sprite": "water",
+    "info": [
+        "Its short feet are tipped with suction pads that enable it to tirelessly climb slopes and walls."
+    ],
+    "evolvesInto": "Metapod",
+    "evolvesVia": "Level 7",
+    "number": 010,
+    "height": ["1", "0"],
+    "weight": 6.4,
+    "types": ["Bug"],
+    "HP": 45,
+    "Attack": 30,
+    "Defense": 35,
+    "Special": 20,
+    "Speed": 45,
+    "moves": {
+        "natural": [{
+            "Move": "String Shot",
+            "level": 1
+        }, {
+            "Move": "Tackle",
+            "level": 1
+        }],
+        "hm": [],
+        "tm": []
+    }
+}, "Chansey": {
+    "label": "Egg",
+    "sprite": "water",
+    "info": [
+        "A rare and elusive POKÃ©MON that is said to bring happiness to those who manage to get it."
+    ],
+    "evolvesInto": "Blissey",
+    "evolvesVia": "Happiness",
+    "number": 113,
+    "height": ["3", "7"],
+    "weight": 76.3,
+    "types": ["Normal"],
+    "HP": 250,
+    "Attack": 5,
+    "Defense": 5,
+    "Special": 35,
+    "Speed": 50,
+    "moves": {
+        "natural": [{
+            "Move": "Double Slap",
+            "level": 1
+        }, {
+            "Move": "Pound",
+            "level": 1
+        }, {
+            "Move": "Sing",
+            "level": 24
+        }, {
+            "Move": "Growl",
+            "level": 30
+        }, {
+            "Move": "Minimize",
+            "level": 38
+        }, {
+            "Move": "Defense Curl",
+            "level": 44
+        }, {
+            "Move": "Light Screen",
+            "level": 48
+        }, {
+            "Move": "Double-Edge",
+            "level": 54
+        }],
+        "hm": [{
+            "Move": "Strength",
+            "level": 4
+        }, {
+            "Move": "Flash",
+            "level": 5
+        }],
+        "tm": [{
+            "Move": "Mega Punch",
+            "level": 1
+        }, {
+            "Move": "Mega Kick",
+            "level": 5
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Bubble Beam",
+            "level": 11
+        }, {
+            "Move": "Water Gun",
+            "level": 12
+        }, {
+            "Move": "Ice Beam",
+            "level": 13
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Counter",
+            "level": 18
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Solar Beam",
+            "level": 22
+        }, {
+            "Move": "Thunderbolt",
+            "level": 24
+        }, {
+            "Move": "Thunder",
+            "level": 25
+        }, {
+            "Move": "Psychic",
+            "level": 29
+        }, {
+            "Move": "Teleport",
+            "level": 30
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Metronome",
+            "level": 35
+        }, {
+            "Move": "Egg Bomb",
+            "level": 37
+        }, {
+            "Move": "Fire Blast",
+            "level": 38
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Soft-Boiled",
+            "level": 41
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Thunder Wave",
+            "level": 45
+        }, {
+            "Move": "Psywave",
+            "level": 46
+        }, {
+            "Move": "Tri Attack",
+            "level": 49
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Charizard": {
+    "label": "Flame",
+    "sprite": "water",
+    "info": [
+        "Spits fire that is hot enough to melt boulders. Known to cause forest fires unintentionally."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 006,
+    "height": ["5", "7"],
+    "weight": 199.5,
+    "types": ["Fire", "Flying"],
+    "HP": 78,
+    "Attack": 84,
+    "Defense": 78,
+    "Special": 109,
+    "Speed": 100,
+    "moves": {
+        "natural": [{
+            "Move": "Ember",
+            "level": 1
+        }, {
+            "Move": "Growl",
+            "level": 1
+        }, {
+            "Move": "Leer",
+            "level": 1
+        }, {
+            "Move": "Scratch",
+            "level": 1
+        }, {
+            "Move": "Ember",
+            "level": 9
+        }, {
+            "Move": "Leer",
+            "level": 15
+        }, {
+            "Move": "Rage",
+            "level": 24
+        }, {
+            "Move": "Slash",
+            "level": 36
+        }, {
+            "Move": "Flamethrower",
+            "level": 46
+        }, {
+            "Move": "Fire Spin",
+            "level": 55
+        }],
+        "hm": [{
+            "Move": "Cut",
+            "level": 1
+        }, {
+            "Move": "Strength",
+            "level": 4
+        }],
+        "tm": [{
+            "Move": "Mega Punch",
+            "level": 1
+        }, {
+            "Move": "Swords Dance",
+            "level": 3
+        }, {
+            "Move": "Mega Kick",
+            "level": 5
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Counter",
+            "level": 18
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Dragon Rage",
+            "level": 23
+        }, {
+            "Move": "Earthquake",
+            "level": 26
+        }, {
+            "Move": "Fissure",
+            "level": 27
+        }, {
+            "Move": "Dig",
+            "level": 28
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Fire Blast",
+            "level": 38
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Charmander": {
+    "label": "Lizard",
+    "sprite": "water",
+    "info": [
+        "Obviously prefers hot places. When it rains, steam is said to spout from the tip of its tail."
+    ],
+    "evolvesInto": "Charmeleon",
+    "evolvesVia": "Level 16",
+    "number": 004,
+    "height": ["2", "0"],
+    "weight": 18.7,
+    "types": ["Fire"],
+    "HP": 39,
+    "Attack": 52,
+    "Defense": 43,
+    "Special": 60,
+    "Speed": 65,
+    "moves": {
+        "natural": [{
+            "Move": "Growl",
+            "level": 1
+        }, {
+            "Move": "Scratch",
+            "level": 1
+        }, {
+            "Move": "Ember",
+            "level": 9
+        }, {
+            "Move": "Leer",
+            "level": 15
+        }, {
+            "Move": "Rage",
+            "level": 22
+        }, {
+            "Move": "Slash",
+            "level": 30
+        }, {
+            "Move": "Flamethrower",
+            "level": 38
+        }, {
+            "Move": "Fire Spin",
+            "level": 46
+        }],
+        "hm": [{
+            "Move": "Cut",
+            "level": 1
+        }, {
+            "Move": "Strength",
+            "level": 4
+        }],
+        "tm": [{
+            "Move": "Mega Punch",
+            "level": 1
+        }, {
+            "Move": "Swords Dance",
+            "level": 3
+        }, {
+            "Move": "Mega Kick",
+            "level": 5
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Counter",
+            "level": 18
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Dragon Rage",
+            "level": 23
+        }, {
+            "Move": "Dig",
+            "level": 28
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Fire Blast",
+            "level": 38
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Charmeleon": {
+    "label": "Flame",
+    "sprite": "water",
+    "info": [
+        "When it swings its burning tail, it elevates the temperature to unbearably high levels."
+    ],
+    "evolvesInto": "Charizard",
+    "evolvesVia": "Level 36",
+    "number": 005,
+    "height": ["3", "7"],
+    "weight": 41.9,
+    "types": ["Fire"],
+    "HP": 58,
+    "Attack": 64,
+    "Defense": 58,
+    "Special": 80,
+    "Speed": 80,
+    "moves": {
+        "natural": [{
+            "Move": "Ember",
+            "level": 1
+        }, {
+            "Move": "Growl",
+            "level": 1
+        }, {
+            "Move": "Scratch",
+            "level": 1
+        }, {
+            "Move": "Ember",
+            "level": 9
+        }, {
+            "Move": "Leer",
+            "level": 15
+        }, {
+            "Move": "Rage",
+            "level": 24
+        }, {
+            "Move": "Slash",
+            "level": 33
+        }, {
+            "Move": "Flamethrower",
+            "level": 42
+        }, {
+            "Move": "Fire Spin",
+            "level": 56
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Mega Punch",
+            "level": 1
+        }, {
+            "Move": "Swords Dance",
+            "level": 3
+        }, {
+            "Move": "Mega Kick",
+            "level": 5
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Counter",
+            "level": 18
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Dragon Rage",
+            "level": 23
+        }, {
+            "Move": "Dig",
+            "level": 28
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Fire Blast",
+            "level": 38
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Clefable": {
+    "label": "Fairy",
+    "sprite": "water",
+    "info": [
+        "A timid fairy POKÃ©MON that is rarely seen. It will run and hide the moment it senses people."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 036,
+    "height": ["4", "3"],
+    "weight": 88.2,
+    "types": ["Fairy"],
+    "HP": 95,
+    "Attack": 70,
+    "Defense": 73,
+    "Special": 95,
+    "Speed": 60,
+    "moves": {
+        "natural": [{
+            "Move": "Double Slap",
+            "level": 1
+        }, {
+            "Move": "Metronome",
+            "level": 1
+        }, {
+            "Move": "Minimize",
+            "level": 1
+        }, {
+            "Move": "Sing",
+            "level": 1
+        }],
+        "hm": [{
+            "Move": "Strength",
+            "level": 4
+        }, {
+            "Move": "Flash",
+            "level": 5
+        }],
+        "tm": [{
+            "Move": "Strength",
+            "level": 4
+        }, {
+            "Move": "Flash",
+            "level": 5
+        }]
+    }
+}, "Clefairy": {
+    "label": "Fairy",
+    "sprite": "water",
+    "info": [
+        "Its magical and cute appeal has many admirers. It is rare and found only in certain areas."
+    ],
+    "evolvesInto": "Clefable",
+    "evolvesVia": "use Moon Stone",
+    "number": 035,
+    "height": ["2", "0"],
+    "weight": 16.5,
+    "types": ["Fairy"],
+    "HP": 70,
+    "Attack": 45,
+    "Defense": 48,
+    "Special": 60,
+    "Speed": 35,
+    "moves": {
+        "natural": [{
+            "Move": "Growl",
+            "level": 1
+        }, {
+            "Move": "Pound",
+            "level": 1
+        }, {
+            "Move": "Sing",
+            "level": 13
+        }, {
+            "Move": "Double Slap",
+            "level": 18
+        }, {
+            "Move": "Minimize",
+            "level": 24
+        }, {
+            "Move": "Metronome",
+            "level": 31
+        }, {
+            "Move": "Defense Curl",
+            "level": 39
+        }, {
+            "Move": "Light Screen",
+            "level": 48
+        }],
+        "hm": [{
+            "Move": "Strength",
+            "level": 4
+        }, {
+            "Move": "Flash",
+            "level": 5
+        }],
+        "tm": [{
+            "Move": "Mega Punch",
+            "level": 1
+        }, {
+            "Move": "Mega Kick",
+            "level": 5
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Bubble Beam",
+            "level": 11
+        }, {
+            "Move": "Water Gun",
+            "level": 12
+        }, {
+            "Move": "Ice Beam",
+            "level": 13
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Counter",
+            "level": 18
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Solar Beam",
+            "level": 22
+        }, {
+            "Move": "Thunderbolt",
+            "level": 24
+        }, {
+            "Move": "Thunder",
+            "level": 25
+        }, {
+            "Move": "Psychic",
+            "level": 29
+        }, {
+            "Move": "Teleport",
+            "level": 30
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Metronome",
+            "level": 35
+        }, {
+            "Move": "Fire Blast",
+            "level": 38
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Thunder Wave",
+            "level": 45
+        }, {
+            "Move": "Psywave",
+            "level": 46
+        }, {
+            "Move": "Tri Attack",
+            "level": 49
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Cloyster": {
+    "label": "Bivalve",
+    "sprite": "water",
+    "info": [
+        "When attacked, it launches its horns in quick volleys. Its innards have never been seen."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 091,
+    "height": ["4", "11"],
+    "weight": 292.1,
+    "types": ["Water", "Ice"],
+    "HP": 50,
+    "Attack": 95,
+    "Defense": 180,
+    "Special": 85,
+    "Speed": 70,
+    "moves": {
+        "natural": [{
+            "Move": "Aurora Beam",
+            "level": 1
+        }, {
+            "Move": "Clamp",
+            "level": 1
+        }, {
+            "Move": "Supersonic",
+            "level": 1
+        }, {
+            "Move": "Withdraw",
+            "level": 1
+        }, {
+            "Move": "Spike Cannon",
+            "level": 50
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Surf",
+            "level": 3
+        }]
+    }
+}, "Cubone": {
+    "label": "Lonely",
+    "sprite": "water",
+    "info": [
+        "Because it never removes its skull helmet, no one has ever seen this POKÃ©MON's real face."
+    ],
+    "evolvesInto": "Marowak",
+    "evolvesVia": "Level 28",
+    "number": 104,
+    "height": ["1", "4"],
+    "weight": 14.3,
+    "types": ["Ground"],
+    "HP": 50,
+    "Attack": 50,
+    "Defense": 95,
+    "Special": 40,
+    "Speed": 35,
+    "moves": {
+        "natural": [{
+            "Move": "Bone Club",
+            "level": 1
+        }, {
+            "Move": "Growl",
+            "level": 1
+        }, {
+            "Move": "Leer",
+            "level": 25
+        }, {
+            "Move": "Focus Energy",
+            "level": 31
+        }, {
+            "Move": "Thrash",
+            "level": 38
+        }, {
+            "Move": "Bonemerang",
+            "level": 43
+        }, {
+            "Move": "Rage",
+            "level": 46
+        }],
+        "hm": [{
+            "Move": "Strength",
+            "level": 4
+        }],
+        "tm": [{
+            "Move": "Mega Punch",
+            "level": 1
+        }, {
+            "Move": "Mega Kick",
+            "level": 5
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Bubble Beam",
+            "level": 11
+        }, {
+            "Move": "Water Gun",
+            "level": 12
+        }, {
+            "Move": "Ice Beam",
+            "level": 13
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Counter",
+            "level": 18
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Earthquake",
+            "level": 26
+        }, {
+            "Move": "Fissure",
+            "level": 27
+        }, {
+            "Move": "Dig",
+            "level": 28
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Fire Blast",
+            "level": 38
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Dewgong": {
+    "label": "Sea Lion",
+    "sprite": "water",
+    "info": [
+        "Stores thermal energy in its body. Swims at a steady 8 knots even in intensely cold waters."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 087,
+    "height": ["5", "7"],
+    "weight": 264.6,
+    "types": ["Water", "Ice"],
+    "HP": 90,
+    "Attack": 70,
+    "Defense": 80,
+    "Special": 70,
+    "Speed": 70,
+    "moves": {
+        "natural": [{
+            "Move": "Aurora Beam",
+            "level": 1
+        }, {
+            "Move": "Growl",
+            "level": 1
+        }, {
+            "Move": "Headbutt",
+            "level": 1
+        }, {
+            "Move": "Growl",
+            "level": 30
+        }, {
+            "Move": "Aurora Beam",
+            "level": 35
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Take Down",
+            "level": 50
+        }, {
+            "Move": "Ice Beam",
+            "level": 56
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Horn Drill",
+            "level": 7
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Bubble Beam",
+            "level": 11
+        }, {
+            "Move": "Water Gun",
+            "level": 12
+        }, {
+            "Move": "Ice Beam",
+            "level": 13
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Pay Day",
+            "level": 16
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Diglett": {
+    "label": "Mole",
+    "sprite": "water",
+    "info": [
+        "Lives about one yard underground where it feeds on plant roots. It sometimes appears above ground."
+    ],
+    "evolvesInto": "Dugtrio",
+    "evolvesVia": "Level 26",
+    "number": 050,
+    "height": ["0", "8"],
+    "weight": 1.8,
+    "types": ["Ground"],
+    "HP": 10,
+    "Attack": 55,
+    "Defense": 25,
+    "Special": 35,
+    "Speed": 95,
+    "moves": {
+        "natural": [{
+            "Move": "Scratch",
+            "level": 1
+        }, {
+            "Move": "Growl",
+            "level": 15
+        }, {
+            "Move": "Dig",
+            "level": 19
+        }, {
+            "Move": "Sand Attack",
+            "level": 24
+        }, {
+            "Move": "Slash",
+            "level": 31
+        }, {
+            "Move": "Earthquake",
+            "level": 40
+        }],
+        "hm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Earthquake",
+            "level": 26
+        }, {
+            "Move": "Fissure",
+            "level": 27
+        }, {
+            "Move": "Dig",
+            "level": 28
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Rock Slide",
+            "level": 48
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }],
+        "tm": [{
+            "Move": "Scratch",
+            "level": 1
+        }, {
+            "Move": "Growl",
+            "level": 15
+        }, {
+            "Move": "Dig",
+            "level": 19
+        }, {
+            "Move": "Sand Attack",
+            "level": 24
+        }, {
+            "Move": "Slash",
+            "level": 31
+        }, {
+            "Move": "Earthquake",
+            "level": 40
+        }]
+    }
+}, "Ditto": {
+    "label": "Transform",
+    "sprite": "water",
+    "info": [
+        "Capable of copying an enemy's genetic code to instantly transform itself into a duplicate of the enemy."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 132,
+    "height": ["1", "0"],
+    "weight": 8.8,
+    "types": ["Normal"],
+    "HP": 48,
+    "Attack": 48,
+    "Defense": 48,
+    "Special": 48,
+    "Speed": 48,
+    "moves": {
+        "natural": [{
+            "Move": "Transform",
+            "level": 1
+        }],
+        "hm": [],
+        "tm": []
+    }
+}, "Dodrio": {
+    "label": "Triple Bird",
+    "sprite": "water",
+    "info": [
+        "Uses its three brains to execute complex plans. While two heads sleep, one head stays awake."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 085,
+    "height": ["5", "11"],
+    "weight": 187.8,
+    "types": ["Normal", "Flying"],
+    "HP": 60,
+    "Attack": 110,
+    "Defense": 70,
+    "Special": 60,
+    "Speed": 100,
+    "moves": {
+        "natural": [{
+            "Move": "Fury Attack",
+            "level": 1
+        }, {
+            "Move": "Growl",
+            "level": 1
+        }, {
+            "Move": "Peck",
+            "level": 1
+        }, {
+            "Move": "Growl",
+            "level": 20
+        }, {
+            "Move": "Fury Attack",
+            "level": 24
+        }, {
+            "Move": "Drill Peck",
+            "level": 30
+        }, {
+            "Move": "Rage",
+            "level": 39
+        }, {
+            "Move": "Tri Attack",
+            "level": 45
+        }, {
+            "Move": "Agility",
+            "level": 51
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Whirlwind",
+            "level": 4
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Sky Attack",
+            "level": 43
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Tri Attack",
+            "level": 49
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Doduo": {
+    "label": "Twin Bird",
+    "sprite": "water",
+    "info": [
+        "A bird that makes up for its poor flying with its fast foot speed. Leaves giant footprints."
+    ],
+    "evolvesInto": "Dodrio",
+    "evolvesVia": "Level 31",
+    "number": 084,
+    "height": ["4", "7"],
+    "weight": 86.4,
+    "types": ["Normal", "Flying"],
+    "HP": 35,
+    "Attack": 85,
+    "Defense": 45,
+    "Special": 35,
+    "Speed": 75,
+    "moves": {
+        "natural": [{
+            "Move": "Peck",
+            "level": 1
+        }, {
+            "Move": "Growl",
+            "level": 20
+        }, {
+            "Move": "Fury Attack",
+            "level": 24
+        }, {
+            "Move": "Drill Peck",
+            "level": 30
+        }, {
+            "Move": "Rage",
+            "level": 36
+        }, {
+            "Move": "Tri Attack",
+            "level": 40
+        }, {
+            "Move": "Agility",
+            "level": 44
+        }],
+        "hm": [{
+            "Move": "Fly",
+            "level": 2
+        }],
+        "tm": [{
+            "Move": "Whirlwind",
+            "level": 4
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Sky Attack",
+            "level": 43
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Tri Attack",
+            "level": 49
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Dragonair": {
+    "label": "Dragon",
+    "sprite": "water",
+    "info": [
+        "A mystical POKÃ©MON that exudes a gentle aura. Has the ability to change climate conditions."
+    ],
+    "evolvesInto": "Dragonite",
+    "evolvesVia": "Level 55",
+    "number": 148,
+    "height": ["13", "1"],
+    "weight": 36.4,
+    "types": ["Dragon"],
+    "HP": 61,
+    "Attack": 84,
+    "Defense": 65,
+    "Special": 70,
+    "Speed": 70,
+    "moves": {
+        "natural": [{
+            "Move": "Leer",
+            "level": 1
+        }, {
+            "Move": "Thunder Wave",
+            "level": 1
+        }, {
+            "Move": "Wrap",
+            "level": 1
+        }, {
+            "Move": "Thunder Wave",
+            "level": 10
+        }, {
+            "Move": "Agility",
+            "level": 20
+        }, {
+            "Move": "Slam",
+            "level": 35
+        }, {
+            "Move": "Dragon Rage",
+            "level": 45
+        }, {
+            "Move": "Hyper Beam",
+            "level": 55
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Horn Drill",
+            "level": 7
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Bubble Beam",
+            "level": 11
+        }, {
+            "Move": "Water Gun",
+            "level": 12
+        }, {
+            "Move": "Ice Beam",
+            "level": 13
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Dragon Rage",
+            "level": 23
+        }, {
+            "Move": "Thunderbolt",
+            "level": 24
+        }, {
+            "Move": "Thunder",
+            "level": 25
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Fire Blast",
+            "level": 38
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Thunder Wave",
+            "level": 45
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Dragonite": {
+    "label": "Dragon",
+    "sprite": "water",
+    "info": [
+        "An extremely rarely seen marine POKÃ©MON. Its intelligence is said to match that of humans."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 149,
+    "height": ["7", "3"],
+    "weight": 463,
+    "types": ["Dragon", "Flying"],
+    "HP": 91,
+    "Attack": 134,
+    "Defense": 95,
+    "Special": 100,
+    "Speed": 80,
+    "moves": {
+        "natural": [{
+            "Move": "Agility",
+            "level": 1
+        }, {
+            "Move": "Leer",
+            "level": 1
+        }, {
+            "Move": "Thunder Wave",
+            "level": 1
+        }, {
+            "Move": "Wrap",
+            "level": 1
+        }, {
+            "Move": "Thunder Wave",
+            "level": 10
+        }, {
+            "Move": "Agility",
+            "level": 20
+        }, {
+            "Move": "Slam",
+            "level": 35
+        }, {
+            "Move": "Dragon Rage",
+            "level": 45
+        }, {
+            "Move": "Hyper Beam",
+            "level": 60
+        }],
+        "hm": [{
+            "Move": "Surf",
+            "level": 3
+        }, {
+            "Move": "Strength",
+            "level": 4
+        }],
+        "tm": [{
+            "Move": "Razor Wind",
+            "level": 2
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Horn Drill",
+            "level": 7
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Bubble Beam",
+            "level": 11
+        }, {
+            "Move": "Water Gun",
+            "level": 12
+        }, {
+            "Move": "Ice Beam",
+            "level": 13
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Dragon Rage",
+            "level": 23
+        }, {
+            "Move": "Thunderbolt",
+            "level": 24
+        }, {
+            "Move": "Thunder",
+            "level": 25
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Fire Blast",
+            "level": 38
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Thunder Wave",
+            "level": 45
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Dratini": {
+    "label": "Dragon",
+    "sprite": "water",
+    "info": [
+        "Long considered a mythical POKÃ©MON until recently when a small colony was found living underwater."
+    ],
+    "evolvesInto": "Dragonair",
+    "evolvesVia": "Level 30",
+    "number": 147,
+    "height": ["5", "11"],
+    "weight": 7.3,
+    "types": ["Dragon"],
+    "HP": 41,
+    "Attack": 64,
+    "Defense": 45,
+    "Special": 50,
+    "Speed": 50,
+    "moves": {
+        "natural": [{
+            "Move": "Leer",
+            "level": 1
+        }, {
+            "Move": "Wrap",
+            "level": 1
+        }, {
+            "Move": "Thunder Wave",
+            "level": 10
+        }, {
+            "Move": "Agility",
+            "level": 20
+        }, {
+            "Move": "Slam",
+            "level": 30
+        }, {
+            "Move": "Dragon Rage",
+            "level": 40
+        }, {
+            "Move": "Hyper Beam",
+            "level": 50
+        }],
+        "hm": [{
+            "Move": "Surf",
+            "level": 3
+        }],
+        "tm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Bubble Beam",
+            "level": 11
+        }, {
+            "Move": "Water Gun",
+            "level": 12
+        }, {
+            "Move": "Ice Beam",
+            "level": 13
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Dragon Rage",
+            "level": 23
+        }, {
+            "Move": "Thunderbolt",
+            "level": 24
+        }, {
+            "Move": "Thunder",
+            "level": 25
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Fire Blast",
+            "level": 38
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Thunder Wave",
+            "level": 45
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Drowzee": {
+    "label": "Hypnosis",
+    "sprite": "water",
+    "info": [
+        "Puts enemies to sleep then eats their dreams. Occasionally gets sick from eating bad dreams."
+    ],
+    "evolvesInto": "Hypno",
+    "evolvesVia": "Level 26",
+    "number": 096,
+    "height": ["3", "3"],
+    "weight": 71.4,
+    "types": ["Psychic"],
+    "HP": 60,
+    "Attack": 48,
+    "Defense": 45,
+    "Special": 43,
+    "Speed": 42,
+    "moves": {
+        "natural": [{
+            "Move": "Hypnosis",
+            "level": 1
+        }, {
+            "Move": "Pound",
+            "level": 1
+        }, {
+            "Move": "Disable",
+            "level": 12
+        }, {
+            "Move": "Confusion",
+            "level": 17
+        }, {
+            "Move": "Headbutt",
+            "level": 24
+        }, {
+            "Move": "Poison Gas",
+            "level": 29
+        }, {
+            "Move": "Psychic",
+            "level": 32
+        }, {
+            "Move": "Meditate",
+            "level": 37
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Mega Punch",
+            "level": 1
+        }, {
+            "Move": "Mega Kick",
+            "level": 5
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Counter",
+            "level": 18
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Psychic",
+            "level": 29
+        }, {
+            "Move": "Teleport",
+            "level": 30
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Metronome",
+            "level": 35
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Dream Eater",
+            "level": 42
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Thunder Wave",
+            "level": 45
+        }, {
+            "Move": "Psywave",
+            "level": 46
+        }, {
+            "Move": "Tri Attack",
+            "level": 49
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Dugtrio": {
+    "label": "Mole",
+    "sprite": "water",
+    "info": [
+        "A team of DIGLETT triplets. It triggers huge earthquakes by burrowing 60 miles underground."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 051,
+    "height": ["2", "4"],
+    "weight": 73.4,
+    "types": ["Ground"],
+    "HP": 35,
+    "Attack": 80,
+    "Defense": 50,
+    "Special": 50,
+    "Speed": 120,
+    "moves": {
+        "natural": [{
+            "Move": "Dig",
+            "level": 1
+        }, {
+            "Move": "Growl",
+            "level": 1
+        }, {
+            "Move": "Scratch",
+            "level": 1
+        }, {
+            "Move": "Growl",
+            "level": 15
+        }, {
+            "Move": "Dig",
+            "level": 19
+        }, {
+            "Move": "Sand Attack",
+            "level": 24
+        }, {
+            "Move": "Slash",
+            "level": 35
+        }, {
+            "Move": "Earthquake",
+            "level": 47
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Dig",
+            "level": 1
+        }, {
+            "Move": "Growl",
+            "level": 1
+        }, {
+            "Move": "Scratch",
+            "level": 1
+        }, {
+            "Move": "Growl",
+            "level": 15
+        }, {
+            "Move": "Dig",
+            "level": 19
+        }, {
+            "Move": "Sand Attack",
+            "level": 24
+        }, {
+            "Move": "Slash",
+            "level": 35
+        }, {
+            "Move": "Earthquake",
+            "level": 47
+        }]
+    }
+}, "Eevee": {
+    "label": "Evolution",
+    "sprite": "water",
+    "info": [
+        "Its genetic code is irregular. It may mutate if it is exposed to radiation from element STONEs."
+    ],
+    "evolvesInto": "Espeon",
+    "evolvesVia": "↗",
+    "number": 133,
+    "height": ["1", "0"],
+    "weight": 14.3,
+    "types": ["Normal"],
+    "HP": 55,
+    "Attack": 55,
+    "Defense": 50,
+    "Special": 45,
+    "Speed": 55,
+    "moves": {
+        "natural": [{
+            "Move": "Sand Attack",
+            "level": 1
+        }, {
+            "Move": "Tackle",
+            "level": 1
+        }, {
+            "Move": "Quick Attack",
+            "level": 27
+        }, {
+            "Move": "Tail Whip",
+            "level": 31
+        }, {
+            "Move": "Bite",
+            "level": 37
+        }, {
+            "Move": "Take Down",
+            "level": 45
+        }],
+        "hm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }],
+        "tm": [{
+            "Move": "Tackle",
+            "level": 1
+        }, {
+            "Move": "Tail Whip",
+            "level": 1
+        }, {
+            "Move": "Sand Attack",
+            "level": 8
+        }, {
+            "Move": "Growl",
+            "level": 16
+        }, {
+            "Move": "Quick Attack",
+            "level": 23
+        }, {
+            "Move": "Bite",
+            "level": 30
+        }, {
+            "Move": "Focus Energy",
+            "level": 36
+        }, {
+            "Move": "Take Down",
+            "level": 42
+        }]
+    }
+}, "Ekans": {
+    "label": "Snake",
+    "sprite": "water",
+    "info": [
+        "Moves silently and stealthily. Eats the eggs of birds, such as PIDGEY and SPEAROW, whole."
+    ],
+    "evolvesInto": "Arbok",
+    "evolvesVia": "Level 22",
+    "number": 023,
+    "height": ["6", "7"],
+    "weight": 15.2,
+    "types": ["Poison"],
+    "HP": 35,
+    "Attack": 60,
+    "Defense": 44,
+    "Special": 40,
+    "Speed": 55,
+    "moves": {
+        "natural": [{
+            "Move": "Leer",
+            "level": 1
+        }, {
+            "Move": "Wrap",
+            "level": 1
+        }, {
+            "Move": "Poison Sting",
+            "level": 10
+        }, {
+            "Move": "Bite",
+            "level": 17
+        }, {
+            "Move": "Glare",
+            "level": 24
+        }, {
+            "Move": "Screech",
+            "level": 31
+        }, {
+            "Move": "Acid",
+            "level": 38
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mega Drain",
+            "level": 21
+        }, {
+            "Move": "Earthquake",
+            "level": 26
+        }, {
+            "Move": "Fissure",
+            "level": 27
+        }, {
+            "Move": "Dig",
+            "level": 28
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Rock Slide",
+            "level": 48
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Electabuzz": {
+    "label": "Electric",
+    "sprite": "water",
+    "info": [
+        "Normally found near power plants, they can wander away and cause major blackouts in cities."
+    ],
+    "evolvesInto": "Electivire",
+    "evolvesVia": "trade holdingElectrizer",
+    "number": 125,
+    "height": ["3", "7"],
+    "weight": 66.1,
+    "types": ["Electric"],
+    "HP": 65,
+    "Attack": 83,
+    "Defense": 57,
+    "Special": 95,
+    "Speed": 105,
+    "moves": {
+        "natural": [{
+            "Move": "Leer",
+            "level": 1
+        }, {
+            "Move": "Quick Attack",
+            "level": 1
+        }, {
+            "Move": "Thunder Shock",
+            "level": 34
+        }, {
+            "Move": "Screech",
+            "level": 37
+        }, {
+            "Move": "Thunder Punch",
+            "level": 42
+        }, {
+            "Move": "Light Screen",
+            "level": 49
+        }, {
+            "Move": "Thunder",
+            "level": 54
+        }],
+        "hm": [{
+            "Move": "Strength",
+            "level": 4
+        }, {
+            "Move": "Flash",
+            "level": 5
+        }],
+        "tm": [{
+            "Move": "Mega Punch",
+            "level": 1
+        }, {
+            "Move": "Mega Kick",
+            "level": 5
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Counter",
+            "level": 18
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Thunderbolt",
+            "level": 24
+        }, {
+            "Move": "Thunder",
+            "level": 25
+        }, {
+            "Move": "Psychic",
+            "level": 29
+        }, {
+            "Move": "Teleport",
+            "level": 30
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Metronome",
+            "level": 35
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Thunder Wave",
+            "level": 45
+        }, {
+            "Move": "Psywave",
+            "level": 46
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Electrode": {
+    "label": "Ball",
+    "sprite": "water",
+    "info": [
+        "It stores electric energy under very high pressure. It often explodes with little or no provocation."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 101,
+    "height": ["3", "11"],
+    "weight": 146.8,
+    "types": ["Electric"],
+    "HP": 60,
+    "Attack": 50,
+    "Defense": 70,
+    "Special": 80,
+    "Speed": 140,
+    "moves": {
+        "natural": [{
+            "Move": "Screech",
+            "level": 1
+        }, {
+            "Move": "Sonic Boom",
+            "level": 1
+        }, {
+            "Move": "Tackle",
+            "level": 1
+        }, {
+            "Move": "Sonic Boom",
+            "level": 17
+        }, {
+            "Move": "Self-Destruct",
+            "level": 22
+        }, {
+            "Move": "Light Screen",
+            "level": 29
+        }, {
+            "Move": "Swift",
+            "level": 40
+        }, {
+            "Move": "Explosion",
+            "level": 50
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Thunderbolt",
+            "level": 24
+        }, {
+            "Move": "Thunder",
+            "level": 25
+        }, {
+            "Move": "Teleport",
+            "level": 30
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Self-Destruct",
+            "level": 36
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Thunder Wave",
+            "level": 45
+        }, {
+            "Move": "Explosion",
+            "level": 47
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Exeggcute": {
+    "label": "Egg",
+    "sprite": "water",
+    "info": [
+        "Often mistaken for eggs. When disturbed, they quickly gather and attack in swarms."
+    ],
+    "evolvesInto": "Exeggutor",
+    "evolvesVia": "use Leaf Stone",
+    "number": 102,
+    "height": ["1", "4"],
+    "weight": 5.5,
+    "types": ["Grass", "Psychic"],
+    "HP": 60,
+    "Attack": 40,
+    "Defense": 80,
+    "Special": 60,
+    "Speed": 40,
+    "moves": {
+        "natural": [{
+            "Move": "Barrage",
+            "level": 1
+        }, {
+            "Move": "Hypnosis",
+            "level": 1
+        }, {
+            "Move": "Reflect",
+            "level": 25
+        }, {
+            "Move": "Leech Seed",
+            "level": 28
+        }, {
+            "Move": "Stun Spore",
+            "level": 32
+        }, {
+            "Move": "Poison Powder",
+            "level": 37
+        }, {
+            "Move": "Solar Beam",
+            "level": 42
+        }, {
+            "Move": "Sleep Powder",
+            "level": 48
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Barrage",
+            "level": 1
+        }, {
+            "Move": "Hypnosis",
+            "level": 1
+        }, {
+            "Move": "Reflect",
+            "level": 25
+        }, {
+            "Move": "Leech Seed",
+            "level": 28
+        }, {
+            "Move": "Stun Spore",
+            "level": 32
+        }, {
+            "Move": "Poison Powder",
+            "level": 37
+        }, {
+            "Move": "Solar Beam",
+            "level": 42
+        }, {
+            "Move": "Sleep Powder",
+            "level": 48
+        }]
+    }
+}, "Exeggutor": {
+    "label": "Coconut",
+    "sprite": "water",
+    "info": [
+        "Legend has it that on rare occasions, one of its heads will drop off and continue on as an EXEGGCUTE."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 103,
+    "height": ["6", "7"],
+    "weight": 264.6,
+    "types": ["Grass", "Psychic"],
+    "HP": 95,
+    "Attack": 95,
+    "Defense": 85,
+    "Special": 125,
+    "Speed": 55,
+    "moves": {
+        "natural": [{
+            "Move": "Barrage",
+            "level": 1
+        }, {
+            "Move": "Hypnosis",
+            "level": 1
+        }, {
+            "Move": "Stomp",
+            "level": 28
+        }],
+        "hm": [{
+            "Move": "Strength",
+            "level": 4
+        }],
+        "tm": [{
+            "Move": "Strength",
+            "level": 4
+        }]
+    }
+}, "Farfetchd": {
+    "label": "Wild Duck",
+    "sprite": "water",
+    "info": [
+        "The sprig of green onions it holds is its weapon. It is used much like a metal sword."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 083,
+    "height": ["2", "7"],
+    "weight": 33.1,
+    "types": ["Normal", "Flying"],
+    "HP": 52,
+    "Attack": 65,
+    "Defense": 55,
+    "Special": 58,
+    "Speed": 60,
+    "moves": {
+        "natural": [{
+            "Move": "Peck",
+            "level": 1
+        }, {
+            "Move": "Sand Attack",
+            "level": 1
+        }, {
+            "Move": "Leer",
+            "level": 7
+        }, {
+            "Move": "Fury Attack",
+            "level": 15
+        }, {
+            "Move": "Swords Dance",
+            "level": 23
+        }, {
+            "Move": "Agility",
+            "level": 31
+        }, {
+            "Move": "Slash",
+            "level": 39
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Razor Wind",
+            "level": 2
+        }, {
+            "Move": "Swords Dance",
+            "level": 3
+        }, {
+            "Move": "Whirlwind",
+            "level": 4
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Fearow": {
+    "label": "Beak",
+    "sprite": "water",
+    "info": [
+        "With its huge and magnificent wings, it can keep aloft without ever having to land for rest."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 022,
+    "height": ["3", "11"],
+    "weight": 83.8,
+    "types": ["Normal", "Flying"],
+    "HP": 65,
+    "Attack": 90,
+    "Defense": 65,
+    "Special": 61,
+    "Speed": 100,
+    "moves": {
+        "natural": [{
+            "Move": "Growl",
+            "level": 1
+        }, {
+            "Move": "Leer",
+            "level": 1
+        }, {
+            "Move": "Peck",
+            "level": 1
+        }, {
+            "Move": "Leer",
+            "level": 9
+        }, {
+            "Move": "Fury Attack",
+            "level": 15
+        }, {
+            "Move": "Mirror Move",
+            "level": 25
+        }, {
+            "Move": "Drill Peck",
+            "level": 34
+        }, {
+            "Move": "Agility",
+            "level": 43
+        }],
+        "hm": [{
+            "Move": "Fly",
+            "level": 2
+        }],
+        "tm": [{
+            "Move": "Razor Wind",
+            "level": 2
+        }, {
+            "Move": "Whirlwind",
+            "level": 4
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Sky Attack",
+            "level": 43
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Flareon": {
+    "label": "Flame",
+    "sprite": "water",
+    "info": [
+        "When storing thermal energy in its body, its temperature could soar to over 1600 degrees."
+    ],
+    "evolvesInto": "Sylveon",
+    "evolvesVia": "use Fire Stone",
+    "number": 136,
+    "height": ["2", "11"],
+    "weight": 55.1,
+    "types": ["Fire"],
+    "HP": 65,
+    "Attack": 130,
+    "Defense": 60,
+    "Special": 95,
+    "Speed": 65,
+    "moves": {
+        "natural": [{
+            "Move": "Ember",
+            "level": 1
+        }, {
+            "Move": "Quick Attack",
+            "level": 1
+        }, {
+            "Move": "Sand Attack",
+            "level": 1
+        }, {
+            "Move": "Tackle",
+            "level": 1
+        }, {
+            "Move": "Quick Attack",
+            "level": 27
+        }, {
+            "Move": "Ember",
+            "level": 31
+        }, {
+            "Move": "Tail Whip",
+            "level": 37
+        }, {
+            "Move": "Bite",
+            "level": 40
+        }, {
+            "Move": "Leer",
+            "level": 42
+        }, {
+            "Move": "Fire Spin",
+            "level": 44
+        }, {
+            "Move": "Rage",
+            "level": 48
+        }, {
+            "Move": "Flamethrower",
+            "level": 54
+        }],
+        "hm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Fire Blast",
+            "level": 38
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }],
+        "tm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Fire Blast",
+            "level": 38
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Gastly": {
+    "label": "Gas",
+    "sprite": "water",
+    "info": [
+        "Almost invisible, this gaseous POKÃ©MON cloaks the target and puts it to sleep without notice."
+    ],
+    "evolvesInto": "Haunter",
+    "evolvesVia": "Level 25",
+    "number": 092,
+    "height": ["4", "3"],
+    "weight": 0.2,
+    "types": ["Ghost", "Poison"],
+    "HP": 30,
+    "Attack": 35,
+    "Defense": 30,
+    "Special": 100,
+    "Speed": 80,
+    "moves": {
+        "natural": [{
+            "Move": "Confuse Ray",
+            "level": 1
+        }, {
+            "Move": "Lick",
+            "level": 1
+        }, {
+            "Move": "Night Shade",
+            "level": 1
+        }, {
+            "Move": "Hypnosis",
+            "level": 27
+        }, {
+            "Move": "Dream Eater",
+            "level": 35
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Confuse Ray",
+            "level": 1
+        }, {
+            "Move": "Lick",
+            "level": 1
+        }, {
+            "Move": "Night Shade",
+            "level": 1
+        }, {
+            "Move": "Hypnosis",
+            "level": 27
+        }, {
+            "Move": "Dream Eater",
+            "level": 35
+        }]
+    }
+}, "Gengar": {
+    "label": "Shadow",
+    "sprite": "water",
+    "info": [
+        "Under a full moon, this POKÃ©MON likes to mimic the shadows of people and laugh at their fright."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 094,
+    "height": ["4", "11"],
+    "weight": 89.3,
+    "types": ["Ghost", "Poison"],
+    "HP": 60,
+    "Attack": 65,
+    "Defense": 60,
+    "Special": 130,
+    "Speed": 110,
+    "moves": {
+        "natural": [{
+            "Move": "Confuse Ray",
+            "level": 1
+        }, {
+            "Move": "Lick",
+            "level": 1
+        }, {
+            "Move": "Night Shade",
+            "level": 1
+        }, {
+            "Move": "Hypnosis",
+            "level": 29
+        }, {
+            "Move": "Dream Eater",
+            "level": 38
+        }],
+        "hm": [{
+            "Move": "Strength",
+            "level": 4
+        }],
+        "tm": [{
+            "Move": "Mega Punch",
+            "level": 1
+        }, {
+            "Move": "Mega Kick",
+            "level": 5
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Counter",
+            "level": 18
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mega Drain",
+            "level": 21
+        }, {
+            "Move": "Thunderbolt",
+            "level": 24
+        }, {
+            "Move": "Thunder",
+            "level": 25
+        }, {
+            "Move": "Psychic",
+            "level": 29
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Metronome",
+            "level": 35
+        }, {
+            "Move": "Self-Destruct",
+            "level": 36
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Dream Eater",
+            "level": 42
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Psywave",
+            "level": 46
+        }, {
+            "Move": "Explosion",
+            "level": 47
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Geodude": {
+    "label": "Rock",
+    "sprite": "water",
+    "info": [
+        "Found in fields and mountains. Mistaking them for boulders, people often step or trip on them."
+    ],
+    "evolvesInto": "Graveler",
+    "evolvesVia": "Level 25",
+    "number": 074,
+    "height": ["1", "4"],
+    "weight": 44.1,
+    "types": ["Rock", "Ground"],
+    "HP": 40,
+    "Attack": 80,
+    "Defense": 100,
+    "Special": 30,
+    "Speed": 20,
+    "moves": {
+        "natural": [{
+            "Move": "Tackle",
+            "level": 1
+        }, {
+            "Move": "Defense Curl",
+            "level": 11
+        }, {
+            "Move": "Rock Throw",
+            "level": 16
+        }, {
+            "Move": "Self-Destruct",
+            "level": 21
+        }, {
+            "Move": "Harden",
+            "level": 26
+        }, {
+            "Move": "Earthquake",
+            "level": 31
+        }, {
+            "Move": "Explosion",
+            "level": 36
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Mega Punch",
+            "level": 1
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Counter",
+            "level": 18
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Earthquake",
+            "level": 26
+        }, {
+            "Move": "Fissure",
+            "level": 27
+        }, {
+            "Move": "Dig",
+            "level": 28
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Metronome",
+            "level": 35
+        }, {
+            "Move": "Self-Destruct",
+            "level": 36
+        }, {
+            "Move": "Fire Blast",
+            "level": 38
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Explosion",
+            "level": 47
+        }, {
+            "Move": "Rock Slide",
+            "level": 48
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Gloom": {
+    "label": "Weed",
+    "sprite": "water",
+    "info": [
+        "The fluid that oozes from its mouth isn't drool. It is a nectar that is used to attract prey."
+    ],
+    "evolvesInto": "Vileplume",
+    "evolvesVia": "↗",
+    "number": 044,
+    "height": ["2", "7"],
+    "weight": 19,
+    "types": ["Grass", "Poison"],
+    "HP": 60,
+    "Attack": 65,
+    "Defense": 70,
+    "Special": 85,
+    "Speed": 40,
+    "moves": {
+        "natural": [{
+            "Move": "Absorb",
+            "level": 1
+        }, {
+            "Move": "Poison Powder",
+            "level": 1
+        }, {
+            "Move": "Stun Spore",
+            "level": 1
+        }, {
+            "Move": "Poison Powder",
+            "level": 15
+        }, {
+            "Move": "Stun Spore",
+            "level": 17
+        }, {
+            "Move": "Sleep Powder",
+            "level": 19
+        }, {
+            "Move": "Acid",
+            "level": 28
+        }, {
+            "Move": "Petal Dance",
+            "level": 38
+        }, {
+            "Move": "Solar Beam",
+            "level": 52
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Swords Dance",
+            "level": 3
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mega Drain",
+            "level": 21
+        }, {
+            "Move": "Solar Beam",
+            "level": 22
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Golbat": {
+    "label": "Bat",
+    "sprite": "water",
+    "info": [
+        "Once it strikes, it will not stop draining energy from the victim even if it gets too heavy to fly."
+    ],
+    "evolvesInto": "Crobat",
+    "evolvesVia": "Happiness",
+    "number": 042,
+    "height": ["5", "3"],
+    "weight": 121.3,
+    "types": ["Poison", "Flying"],
+    "HP": 75,
+    "Attack": 80,
+    "Defense": 70,
+    "Special": 65,
+    "Speed": 90,
+    "moves": {
+        "natural": [{
+            "Move": "Bite",
+            "level": 1
+        }, {
+            "Move": "Leech Life",
+            "level": 1
+        }, {
+            "Move": "Screech",
+            "level": 1
+        }, {
+            "Move": "Supersonic",
+            "level": 10
+        }, {
+            "Move": "Bite",
+            "level": 15
+        }, {
+            "Move": "Confuse Ray",
+            "level": 21
+        }, {
+            "Move": "Wing Attack",
+            "level": 32
+        }, {
+            "Move": "Haze",
+            "level": 43
+        }],
+        "hm": [{
+            "Move": "Razor Wind",
+            "level": 2
+        }, {
+            "Move": "Whirlwind",
+            "level": 4
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mega Drain",
+            "level": 21
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }],
+        "tm": [{
+            "Move": "Bite",
+            "level": 1
+        }, {
+            "Move": "Leech Life",
+            "level": 1
+        }, {
+            "Move": "Screech",
+            "level": 1
+        }, {
+            "Move": "Supersonic",
+            "level": 10
+        }, {
+            "Move": "Bite",
+            "level": 15
+        }, {
+            "Move": "Confuse Ray",
+            "level": 21
+        }, {
+            "Move": "Wing Attack",
+            "level": 32
+        }, {
+            "Move": "Haze",
+            "level": 43
+        }]
+    }
+}, "Goldeen": {
+    "label": "Goldfish",
+    "sprite": "water",
+    "info": [
+        "Its tail fin billows like an elegant ballroom dress, giving it the nickname of the Water Queen."
+    ],
+    "evolvesInto": "Seaking",
+    "evolvesVia": "Level 33",
+    "number": 118,
+    "height": ["2", "0"],
+    "weight": 33.1,
+    "types": ["Water"],
+    "HP": 45,
+    "Attack": 67,
+    "Defense": 60,
+    "Special": 35,
+    "Speed": 63,
+    "moves": {
+        "natural": [{
+            "Move": "Peck",
+            "level": 1
+        }, {
+            "Move": "Tail Whip",
+            "level": 1
+        }, {
+            "Move": "Supersonic",
+            "level": 19
+        }, {
+            "Move": "Horn Attack",
+            "level": 24
+        }, {
+            "Move": "Fury Attack",
+            "level": 30
+        }, {
+            "Move": "Waterfall",
+            "level": 37
+        }, {
+            "Move": "Horn Drill",
+            "level": 45
+        }, {
+            "Move": "Agility",
+            "level": 54
+        }],
+        "hm": [{
+            "Move": "Surf",
+            "level": 3
+        }],
+        "tm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Horn Drill",
+            "level": 7
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Bubble Beam",
+            "level": 11
+        }, {
+            "Move": "Water Gun",
+            "level": 12
+        }, {
+            "Move": "Ice Beam",
+            "level": 13
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Golduck": {
+    "label": "Duck",
+    "sprite": "water",
+    "info": [
+        "Often seen swimming elegantly by lake shores. It is often mistaken for the Japanese monster, Kappa."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 055,
+    "height": ["5", "7"],
+    "weight": 168.9,
+    "types": ["Water"],
+    "HP": 80,
+    "Attack": 82,
+    "Defense": 78,
+    "Special": 95,
+    "Speed": 85,
+    "moves": {
+        "natural": [{
+            "Move": "Disable",
+            "level": 1
+        }, {
+            "Move": "Scratch",
+            "level": 1
+        }, {
+            "Move": "Tail Whip",
+            "level": 1
+        }, {
+            "Move": "Tail Whip",
+            "level": 28
+        }, {
+            "Move": "Disable",
+            "level": 31
+        }, {
+            "Move": "Confusion",
+            "level": 39
+        }, {
+            "Move": "Fury Swipes",
+            "level": 48
+        }, {
+            "Move": "Hydro Pump",
+            "level": 59
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Mega Punch",
+            "level": 1
+        }, {
+            "Move": "Mega Kick",
+            "level": 5
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Bubble Beam",
+            "level": 11
+        }, {
+            "Move": "Water Gun",
+            "level": 12
+        }, {
+            "Move": "Ice Beam",
+            "level": 13
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Pay Day",
+            "level": 16
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Counter",
+            "level": 18
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Dig",
+            "level": 28
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Golem": {
+    "label": "Megaton",
+    "sprite": "water",
+    "info": [
+        "Its boulder-like body is extremely hard. It can easily withstand dynamite blasts without damage."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 076,
+    "height": ["4", "7"],
+    "weight": 661.4,
+    "types": ["Rock", "Ground"],
+    "HP": 80,
+    "Attack": 120,
+    "Defense": 130,
+    "Special": 55,
+    "Speed": 45,
+    "moves": {
+        "natural": [{
+            "Move": "Defense Curl",
+            "level": 1
+        }, {
+            "Move": "Tackle",
+            "level": 1
+        }, {
+            "Move": "Defense Curl",
+            "level": 11
+        }, {
+            "Move": "Rock Throw",
+            "level": 16
+        }, {
+            "Move": "Self-Destruct",
+            "level": 21
+        }, {
+            "Move": "Harden",
+            "level": 29
+        }, {
+            "Move": "Earthquake",
+            "level": 36
+        }, {
+            "Move": "Explosion",
+            "level": 43
+        }],
+        "hm": [{
+            "Move": "Strength",
+            "level": 4
+        }],
+        "tm": [{
+            "Move": "Mega Punch",
+            "level": 1
+        }, {
+            "Move": "Mega Kick",
+            "level": 5
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Counter",
+            "level": 18
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Earthquake",
+            "level": 26
+        }, {
+            "Move": "Fissure",
+            "level": 27
+        }, {
+            "Move": "Dig",
+            "level": 28
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Metronome",
+            "level": 35
+        }, {
+            "Move": "Self-Destruct",
+            "level": 36
+        }, {
+            "Move": "Fire Blast",
+            "level": 38
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Explosion",
+            "level": 47
+        }, {
+            "Move": "Rock Slide",
+            "level": 48
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Graveler": {
+    "label": "Rock",
+    "sprite": "water",
+    "info": [
+        "Rolls down slopes to move. It rolls over any obstacle without slowing or changing its direction."
+    ],
+    "evolvesInto": "Golem",
+    "evolvesVia": "Trade",
+    "number": 075,
+    "height": ["3", "3"],
+    "weight": 231.5,
+    "types": ["Rock", "Ground"],
+    "HP": 55,
+    "Attack": 95,
+    "Defense": 115,
+    "Special": 45,
+    "Speed": 35,
+    "moves": {
+        "natural": [{
+            "Move": "Defense Curl",
+            "level": 1
+        }, {
+            "Move": "Tackle",
+            "level": 1
+        }, {
+            "Move": "Defense Curl",
+            "level": 11
+        }, {
+            "Move": "Rock Throw",
+            "level": 16
+        }, {
+            "Move": "Self-Destruct",
+            "level": 21
+        }, {
+            "Move": "Harden",
+            "level": 29
+        }, {
+            "Move": "Earthquake",
+            "level": 36
+        }, {
+            "Move": "Explosion",
+            "level": 43
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Mega Punch",
+            "level": 1
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Counter",
+            "level": 18
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Earthquake",
+            "level": 26
+        }, {
+            "Move": "Fissure",
+            "level": 27
+        }, {
+            "Move": "Dig",
+            "level": 28
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Metronome",
+            "level": 35
+        }, {
+            "Move": "Self-Destruct",
+            "level": 36
+        }, {
+            "Move": "Fire Blast",
+            "level": 38
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Explosion",
+            "level": 47
+        }, {
+            "Move": "Rock Slide",
+            "level": 48
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Grimer": {
+    "label": "Sludge",
+    "sprite": "water",
+    "info": [
+        "Appears in filthy areas. Thrives by sucking up polluted sludge that is pumped out of factories."
+    ],
+    "evolvesInto": "Muk",
+    "evolvesVia": "Level 38",
+    "number": 088,
+    "height": ["2", "11"],
+    "weight": 66.1,
+    "types": ["Poison"],
+    "HP": 80,
+    "Attack": 80,
+    "Defense": 50,
+    "Special": 40,
+    "Speed": 25,
+    "moves": {
+        "natural": [{
+            "Move": "Disable",
+            "level": 1
+        }, {
+            "Move": "Pound",
+            "level": 1
+        }, {
+            "Move": "Poison Gas",
+            "level": 30
+        }, {
+            "Move": "Minimize",
+            "level": 33
+        }, {
+            "Move": "Sludge",
+            "level": 37
+        }, {
+            "Move": "Harden",
+            "level": 42
+        }, {
+            "Move": "Screech",
+            "level": 48
+        }, {
+            "Move": "Acid Armor",
+            "level": 55
+        }],
+        "hm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mega Drain",
+            "level": 21
+        }, {
+            "Move": "Thunderbolt",
+            "level": 24
+        }, {
+            "Move": "Thunder",
+            "level": 25
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Self-Destruct",
+            "level": 36
+        }, {
+            "Move": "Fire Blast",
+            "level": 38
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Explosion",
+            "level": 47
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }],
+        "tm": [{
+            "Move": "Disable",
+            "level": 1
+        }, {
+            "Move": "Pound",
+            "level": 1
+        }, {
+            "Move": "Poison Gas",
+            "level": 30
+        }, {
+            "Move": "Minimize",
+            "level": 33
+        }, {
+            "Move": "Sludge",
+            "level": 37
+        }, {
+            "Move": "Harden",
+            "level": 42
+        }, {
+            "Move": "Screech",
+            "level": 48
+        }, {
+            "Move": "Acid Armor",
+            "level": 55
+        }]
+    }
+}, "Growlithe": {
+    "label": "Puppy",
+    "sprite": "water",
+    "info": [
+        "Very protective of its territory. It will bark and bite to repel intruders from its space."
+    ],
+    "evolvesInto": "Arcanine",
+    "evolvesVia": "use Fire Stone",
+    "number": 058,
+    "height": ["2", "4"],
+    "weight": 41.9,
+    "types": ["Fire"],
+    "HP": 55,
+    "Attack": 70,
+    "Defense": 45,
+    "Special": 70,
+    "Speed": 60,
+    "moves": {
+        "natural": [{
+            "Move": "Bite",
+            "level": 1
+        }, {
+            "Move": "Roar",
+            "level": 1
+        }, {
+            "Move": "Ember",
+            "level": 18
+        }, {
+            "Move": "Leer",
+            "level": 23
+        }, {
+            "Move": "Take Down",
+            "level": 30
+        }, {
+            "Move": "Agility",
+            "level": 39
+        }, {
+            "Move": "Flamethrower",
+            "level": 50
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Bite",
+            "level": 1
+        }, {
+            "Move": "Roar",
+            "level": 1
+        }, {
+            "Move": "Ember",
+            "level": 18
+        }, {
+            "Move": "Leer",
+            "level": 23
+        }, {
+            "Move": "Take Down",
+            "level": 30
+        }, {
+            "Move": "Agility",
+            "level": 39
+        }, {
+            "Move": "Flamethrower",
+            "level": 50
+        }]
+    }
+}, "Gyarados": {
+    "label": "Atrocious",
+    "sprite": "water",
+    "info": [
+        "Rarely seen in the wild. Huge and vicious, it is capable of destroying entire cities in a rage."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 130,
+    "height": ["21", "4"],
+    "weight": 518.1,
+    "types": ["Water", "Flying"],
+    "HP": 95,
+    "Attack": 125,
+    "Defense": 79,
+    "Special": 60,
+    "Speed": 81,
+    "moves": {
+        "natural": [{
+            "Move": "Bite",
+            "level": 1
+        }, {
+            "Move": "Dragon Rage",
+            "level": 1
+        }, {
+            "Move": "Hydro Pump",
+            "level": 1
+        }, {
+            "Move": "Leer",
+            "level": 1
+        }, {
+            "Move": "Bite",
+            "level": 20
+        }, {
+            "Move": "Dragon Rage",
+            "level": 25
+        }, {
+            "Move": "Leer",
+            "level": 32
+        }, {
+            "Move": "Hydro Pump",
+            "level": 41
+        }, {
+            "Move": "Hyper Beam",
+            "level": 52
+        }],
+        "hm": [{
+            "Move": "Surf",
+            "level": 3
+        }, {
+            "Move": "Strength",
+            "level": 4
+        }],
+        "tm": [{
+            "Move": "Surf",
+            "level": 3
+        }, {
+            "Move": "Strength",
+            "level": 4
+        }]
+    }
+}, "Haunter": {
+    "label": "Gas",
+    "sprite": "water",
+    "info": [
+        "Because of its ability to slip through block walls, it is said to be from another dimension."
+    ],
+    "evolvesInto": "Gengar",
+    "evolvesVia": "Trade",
+    "number": 093,
+    "height": ["5", "3"],
+    "weight": 0.2,
+    "types": ["Ghost", "Poison"],
+    "HP": 45,
+    "Attack": 50,
+    "Defense": 45,
+    "Special": 115,
+    "Speed": 95,
+    "moves": {
+        "natural": [{
+            "Move": "Confuse Ray",
+            "level": 1
+        }, {
+            "Move": "Lick",
+            "level": 1
+        }, {
+            "Move": "Night Shade",
+            "level": 1
+        }, {
+            "Move": "Hypnosis",
+            "level": 29
+        }, {
+            "Move": "Dream Eater",
+            "level": 38
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Confuse Ray",
+            "level": 1
+        }, {
+            "Move": "Lick",
+            "level": 1
+        }, {
+            "Move": "Night Shade",
+            "level": 1
+        }, {
+            "Move": "Hypnosis",
+            "level": 29
+        }, {
+            "Move": "Dream Eater",
+            "level": 38
+        }]
+    }
+}, "Hitmonchan": {
+    "label": "Punching",
+    "sprite": "water",
+    "info": [
+        "While apparently doing nothing, it fires punches in lightning fast volleys that are impossible to see."
+    ],
+    "evolvesInto": "Hitmontop",
+    "evolvesVia": "Level 20,Attack = Defense",
+    "number": 107,
+    "height": ["4", "7"],
+    "weight": 110.7,
+    "types": ["Fighting"],
+    "HP": 50,
+    "Attack": 105,
+    "Defense": 79,
+    "Special": 35,
+    "Speed": 76,
+    "moves": {
+        "natural": [{
+            "Move": "Agility",
+            "level": 1
+        }, {
+            "Move": "Comet Punch",
+            "level": 1
+        }, {
+            "Move": "Fire Punch",
+            "level": 33
+        }, {
+            "Move": "Ice Punch",
+            "level": 38
+        }, {
+            "Move": "Thunder Punch",
+            "level": 43
+        }, {
+            "Move": "Mega Punch",
+            "level": 48
+        }, {
+            "Move": "Counter",
+            "level": 53
+        }],
+        "hm": [{
+            "Move": "Strength",
+            "level": 4
+        }],
+        "tm": [{
+            "Move": "Mega Punch",
+            "level": 1
+        }, {
+            "Move": "Mega Kick",
+            "level": 5
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Counter",
+            "level": 18
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Metronome",
+            "level": 35
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Hitmonlee": {
+    "label": "Kicking",
+    "sprite": "water",
+    "info": [
+        "When in a hurry, its legs lengthen progressively. It runs smoothly with extra long, loping strides."
+    ],
+    "evolvesInto": "Hitmonchan",
+    "evolvesVia": "Level 20,Attack < Defense",
+    "number": 106,
+    "height": ["4", "11"],
+    "weight": 109.8,
+    "types": ["Fighting"],
+    "HP": 50,
+    "Attack": 120,
+    "Defense": 53,
+    "Special": 35,
+    "Speed": 87,
+    "moves": {
+        "natural": [{
+            "Move": "Double Kick",
+            "level": 1
+        }, {
+            "Move": "Meditate",
+            "level": 1
+        }, {
+            "Move": "Rolling Kick",
+            "level": 33
+        }, {
+            "Move": "Jump Kick",
+            "level": 38
+        }, {
+            "Move": "Focus Energy",
+            "level": 43
+        }, {
+            "Move": "High Jump Kick",
+            "level": 48
+        }, {
+            "Move": "Mega Kick",
+            "level": 53
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Mega Punch",
+            "level": 1
+        }, {
+            "Move": "Mega Kick",
+            "level": 5
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Counter",
+            "level": 18
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Metronome",
+            "level": 35
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Horsea": {
+    "label": "Dragon",
+    "sprite": "water",
+    "info": [
+        "Known to shoot down flying bugs with precision blasts of ink from the surface of the water."
+    ],
+    "evolvesInto": "Seadra",
+    "evolvesVia": "Level 32",
+    "number": 116,
+    "height": ["1", "4"],
+    "weight": 17.6,
+    "types": ["Water"],
+    "HP": 30,
+    "Attack": 40,
+    "Defense": 70,
+    "Special": 70,
+    "Speed": 60,
+    "moves": {
+        "natural": [{
+            "Move": "Bubble",
+            "level": 1
+        }, {
+            "Move": "Smokescreen",
+            "level": 19
+        }, {
+            "Move": "Leer",
+            "level": 24
+        }, {
+            "Move": "Water Gun",
+            "level": 30
+        }, {
+            "Move": "Agility",
+            "level": 37
+        }, {
+            "Move": "Hydro Pump",
+            "level": 45
+        }],
+        "hm": [{
+            "Move": "Surf",
+            "level": 3
+        }],
+        "tm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Bubble Beam",
+            "level": 11
+        }, {
+            "Move": "Water Gun",
+            "level": 12
+        }, {
+            "Move": "Ice Beam",
+            "level": 13
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Hypno": {
+    "label": "Hypnosis",
+    "sprite": "water",
+    "info": [
+        "When it locks eyes with an enemy, it will use a mix of PSI moves such as HYPNOSIS and CONFUSION."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 097,
+    "height": ["5", "3"],
+    "weight": 166.7,
+    "types": ["Psychic"],
+    "HP": 85,
+    "Attack": 73,
+    "Defense": 70,
+    "Special": 73,
+    "Speed": 67,
+    "moves": {
+        "natural": [{
+            "Move": "Confusion",
+            "level": 1
+        }, {
+            "Move": "Disable",
+            "level": 1
+        }, {
+            "Move": "Hypnosis",
+            "level": 1
+        }, {
+            "Move": "Pound",
+            "level": 1
+        }, {
+            "Move": "Disable",
+            "level": 12
+        }, {
+            "Move": "Confusion",
+            "level": 17
+        }, {
+            "Move": "Headbutt",
+            "level": 24
+        }, {
+            "Move": "Poison Gas",
+            "level": 33
+        }, {
+            "Move": "Psychic",
+            "level": 37
+        }, {
+            "Move": "Meditate",
+            "level": 43
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Mega Punch",
+            "level": 1
+        }, {
+            "Move": "Mega Kick",
+            "level": 5
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Counter",
+            "level": 18
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Psychic",
+            "level": 29
+        }, {
+            "Move": "Teleport",
+            "level": 30
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Metronome",
+            "level": 35
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Dream Eater",
+            "level": 42
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Thunder Wave",
+            "level": 45
+        }, {
+            "Move": "Psywave",
+            "level": 46
+        }, {
+            "Move": "Tri Attack",
+            "level": 49
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Ivysaur": {
+    "label": "Seed",
+    "sprite": "water",
+    "info": [
+        "When the bulb on its back grows large, it appears to lose the ability to stand on its hind legs."
+    ],
+    "evolvesInto": "Venusaur",
+    "evolvesVia": "Level 32",
+    "number": 002,
+    "height": ["3", "3"],
+    "weight": 28.7,
+    "types": ["Grass", "Poison"],
+    "HP": 60,
+    "Attack": 62,
+    "Defense": 63,
+    "Special": 80,
+    "Speed": 60,
+    "moves": {
+        "natural": [{
+            "Move": "Growl",
+            "level": 1
+        }, {
+            "Move": "Leech Seed",
+            "level": 1
+        }, {
+            "Move": "Tackle",
+            "level": 1
+        }, {
+            "Move": "Leech Seed",
+            "level": 7
+        }, {
+            "Move": "Vine Whip",
+            "level": 13
+        }, {
+            "Move": "Poison Powder",
+            "level": 22
+        }, {
+            "Move": "Razor Leaf",
+            "level": 30
+        }, {
+            "Move": "Growth",
+            "level": 38
+        }, {
+            "Move": "Sleep Powder",
+            "level": 46
+        }, {
+            "Move": "Solar Beam",
+            "level": 54
+        }],
+        "hm": [{
+            "Move": "Cut",
+            "level": 1
+        }],
+        "tm": [{
+            "Move": "Swords Dance",
+            "level": 3
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mega Drain",
+            "level": 21
+        }, {
+            "Move": "Solar Beam",
+            "level": 22
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Jigglypuff": {
+    "label": "Balloon",
+    "sprite": "water",
+    "info": [
+        "When its huge eyes light up, it sings a mysteriously soothing melody that lulls its enemies to sleep."
+    ],
+    "evolvesInto": "Wigglytuff",
+    "evolvesVia": "use Moon Stone",
+    "number": 039,
+    "height": ["1", "8"],
+    "weight": 12.1,
+    "types": ["Normal", "Fairy"],
+    "HP": 115,
+    "Attack": 45,
+    "Defense": 20,
+    "Special": 45,
+    "Speed": 20,
+    "moves": {
+        "natural": [{
+            "Move": "Sing",
+            "level": 1
+        }, {
+            "Move": "Pound",
+            "level": 9
+        }, {
+            "Move": "Disable",
+            "level": 14
+        }, {
+            "Move": "Defense Curl",
+            "level": 19
+        }, {
+            "Move": "Double Slap",
+            "level": 24
+        }, {
+            "Move": "Rest",
+            "level": 29
+        }, {
+            "Move": "Body Slam",
+            "level": 34
+        }, {
+            "Move": "Double-Edge",
+            "level": 39
+        }],
+        "hm": [{
+            "Move": "Strength",
+            "level": 4
+        }, {
+            "Move": "Flash",
+            "level": 5
+        }],
+        "tm": [{
+            "Move": "Mega Punch",
+            "level": 1
+        }, {
+            "Move": "Mega Kick",
+            "level": 5
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Bubble Beam",
+            "level": 11
+        }, {
+            "Move": "Water Gun",
+            "level": 12
+        }, {
+            "Move": "Ice Beam",
+            "level": 13
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Counter",
+            "level": 18
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Solar Beam",
+            "level": 22
+        }, {
+            "Move": "Thunderbolt",
+            "level": 24
+        }, {
+            "Move": "Thunder",
+            "level": 25
+        }, {
+            "Move": "Psychic",
+            "level": 29
+        }, {
+            "Move": "Teleport",
+            "level": 30
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Fire Blast",
+            "level": 38
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Thunder Wave",
+            "level": 45
+        }, {
+            "Move": "Psywave",
+            "level": 46
+        }, {
+            "Move": "Tri Attack",
+            "level": 49
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Jolteon": {
+    "label": "Lightning",
+    "sprite": "water",
+    "info": [
+        "It accumulates negative ions in the atmosphere to blast out 10000-volt lightning bolts."
+    ],
+    "evolvesInto": "Flareon",
+    "evolvesVia": "use Thunderstone",
+    "number": 135,
+    "height": ["2", "7"],
+    "weight": 54,
+    "types": ["Electric"],
+    "HP": 65,
+    "Attack": 65,
+    "Defense": 60,
+    "Special": 110,
+    "Speed": 130,
+    "moves": {
+        "natural": [{
+            "Move": "Quick Attack",
+            "level": 1
+        }, {
+            "Move": "Sand Attack",
+            "level": 1
+        }, {
+            "Move": "Tackle",
+            "level": 1
+        }, {
+            "Move": "Thunder Shock",
+            "level": 1
+        }, {
+            "Move": "Quick Attack",
+            "level": 27
+        }, {
+            "Move": "Thunder Shock",
+            "level": 31
+        }, {
+            "Move": "Tail Whip",
+            "level": 37
+        }, {
+            "Move": "Thunder Wave",
+            "level": 40
+        }, {
+            "Move": "Double Kick",
+            "level": 42
+        }, {
+            "Move": "Agility",
+            "level": 44
+        }, {
+            "Move": "Pin Missile",
+            "level": 48
+        }, {
+            "Move": "Thunder",
+            "level": 54
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Flash",
+            "level": 5
+        }]
+    }
+}, "Jynx": {
+    "label": "Human Shape",
+    "sprite": "water",
+    "info": [
+        "It seductively wiggles its hips as it walks. It can cause people to dance in unison with it."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 124,
+    "height": ["4", "7"],
+    "weight": 89.5,
+    "types": ["Ice", "Psychic"],
+    "HP": 65,
+    "Attack": 50,
+    "Defense": 35,
+    "Special": 115,
+    "Speed": 95,
+    "moves": {
+        "natural": [{
+            "Move": "Lovely Kiss",
+            "level": 1
+        }, {
+            "Move": "Pound",
+            "level": 1
+        }, {
+            "Move": "Lick",
+            "level": 18
+        }, {
+            "Move": "Double Slap",
+            "level": 23
+        }, {
+            "Move": "Ice Punch",
+            "level": 31
+        }, {
+            "Move": "Body Slam",
+            "level": 39
+        }, {
+            "Move": "Thrash",
+            "level": 47
+        }, {
+            "Move": "Blizzard",
+            "level": 58
+        }],
+        "hm": [{
+            "Move": "Mega Punch",
+            "level": 1
+        }, {
+            "Move": "Mega Kick",
+            "level": 5
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Bubble Beam",
+            "level": 11
+        }, {
+            "Move": "Water Gun",
+            "level": 12
+        }, {
+            "Move": "Ice Beam",
+            "level": 13
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Counter",
+            "level": 18
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Psychic",
+            "level": 29
+        }, {
+            "Move": "Teleport",
+            "level": 30
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Metronome",
+            "level": 35
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Psywave",
+            "level": 46
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }],
+        "tm": [{
+            "Move": "Lovely Kiss",
+            "level": 1
+        }, {
+            "Move": "Pound",
+            "level": 1
+        }, {
+            "Move": "Lick",
+            "level": 18
+        }, {
+            "Move": "Double Slap",
+            "level": 23
+        }, {
+            "Move": "Ice Punch",
+            "level": 31
+        }, {
+            "Move": "Body Slam",
+            "level": 39
+        }, {
+            "Move": "Thrash",
+            "level": 47
+        }, {
+            "Move": "Blizzard",
+            "level": 58
+        }]
+    }
+}, "Kabuto": {
+    "label": "Shellfish",
+    "sprite": "water",
+    "info": [
+        "A POKÃ©MON that was resurrected from a fossil found in what was once the ocean floor eons ago."
+    ],
+    "evolvesInto": "Kabutops",
+    "evolvesVia": "Level 40",
+    "number": 140,
+    "height": ["1", "8"],
+    "weight": 25.4,
+    "types": ["Rock", "Water"],
+    "HP": 30,
+    "Attack": 80,
+    "Defense": 90,
+    "Special": 55,
+    "Speed": 55,
+    "moves": {
+        "natural": [{
+            "Move": "Harden",
+            "level": 1
+        }, {
+            "Move": "Scratch",
+            "level": 1
+        }, {
+            "Move": "Absorb",
+            "level": 34
+        }, {
+            "Move": "Slash",
+            "level": 39
+        }, {
+            "Move": "Leer",
+            "level": 44
+        }, {
+            "Move": "Hydro Pump",
+            "level": 49
+        }],
+        "hm": [{
+            "Move": "Surf",
+            "level": 3
+        }],
+        "tm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Bubble Beam",
+            "level": 11
+        }, {
+            "Move": "Water Gun",
+            "level": 12
+        }, {
+            "Move": "Ice Beam",
+            "level": 13
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Kabutops": {
+    "label": "Shellfish",
+    "sprite": "water",
+    "info": [
+        "Its sleek shape is perfect for swimming. It slashes prey with its claws and drains the body fluids."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 141,
+    "height": ["4", "3"],
+    "weight": 89.3,
+    "types": ["Rock", "Water"],
+    "HP": 60,
+    "Attack": 115,
+    "Defense": 105,
+    "Special": 65,
+    "Speed": 80,
+    "moves": {
+        "natural": [{
+            "Move": "Absorb",
+            "level": 1
+        }, {
+            "Move": "Harden",
+            "level": 1
+        }, {
+            "Move": "Scratch",
+            "level": 1
+        }, {
+            "Move": "Absorb",
+            "level": 34
+        }, {
+            "Move": "Slash",
+            "level": 39
+        }, {
+            "Move": "Leer",
+            "level": 46
+        }, {
+            "Move": "Hydro Pump",
+            "level": 53
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Razor Wind",
+            "level": 2
+        }, {
+            "Move": "Swords Dance",
+            "level": 3
+        }, {
+            "Move": "Mega Kick",
+            "level": 5
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Bubble Beam",
+            "level": 11
+        }, {
+            "Move": "Water Gun",
+            "level": 12
+        }, {
+            "Move": "Ice Beam",
+            "level": 13
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Kadabra": {
+    "label": "Psi",
+    "sprite": "water",
+    "info": [
+        "It emits special alpha waves from its body that induce headaches just by being close by."
+    ],
+    "evolvesInto": "Alakazam",
+    "evolvesVia": "Trade",
+    "number": 064,
+    "height": ["4", "3"],
+    "weight": 124.6,
+    "types": ["Psychic"],
+    "HP": 40,
+    "Attack": 35,
+    "Defense": 30,
+    "Special": 120,
+    "Speed": 105,
+    "moves": {
+        "natural": [{
+            "Move": "Confusion",
+            "level": 1
+        }, {
+            "Move": "Disable",
+            "level": 1
+        }, {
+            "Move": "Teleport",
+            "level": 1
+        }, {
+            "Move": "Confusion",
+            "level": 16
+        }, {
+            "Move": "Disable",
+            "level": 20
+        }, {
+            "Move": "Psybeam",
+            "level": 27
+        }, {
+            "Move": "Recover",
+            "level": 31
+        }, {
+            "Move": "Psychic",
+            "level": 38
+        }, {
+            "Move": "Reflect",
+            "level": 42
+        }],
+        "hm": [{
+            "Move": "Flash",
+            "level": 5
+        }],
+        "tm": [{
+            "Move": "Mega Punch",
+            "level": 1
+        }, {
+            "Move": "Mega Kick",
+            "level": 5
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Counter",
+            "level": 18
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Dig",
+            "level": 28
+        }, {
+            "Move": "Psychic",
+            "level": 29
+        }, {
+            "Move": "Teleport",
+            "level": 30
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Metronome",
+            "level": 35
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Thunder Wave",
+            "level": 45
+        }, {
+            "Move": "Psywave",
+            "level": 46
+        }, {
+            "Move": "Tri Attack",
+            "level": 49
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Kakuna": {
+    "label": "Cocoon",
+    "sprite": "water",
+    "info": [
+        "Almost incapable of moving, this POKÃ©MON can only harden its shell to protect itself from predators."
+    ],
+    "evolvesInto": "Beedrill",
+    "evolvesVia": "Level 10",
+    "number": 014,
+    "height": ["2", "0"],
+    "weight": 22,
+    "types": ["Bug", "Poison"],
+    "HP": 45,
+    "Attack": 25,
+    "Defense": 50,
+    "Special": 25,
+    "Speed": 35,
+    "moves": {
+        "natural": [{
+            "Move": "Harden",
+            "level": 1
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Harden",
+            "level": 1
+        }]
+    }
+}, "Kangaskhan": {
+    "label": "Parent",
+    "sprite": "water",
+    "info": [
+        "The infant rarely ventures out of its mother's protective pouch until it is 3 years old."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 115,
+    "height": ["7", "3"],
+    "weight": 176.4,
+    "types": ["Normal"],
+    "HP": 105,
+    "Attack": 95,
+    "Defense": 80,
+    "Special": 40,
+    "Speed": 90,
+    "moves": {
+        "natural": [{
+            "Move": "Comet Punch",
+            "level": 1
+        }, {
+            "Move": "Rage",
+            "level": 1
+        }, {
+            "Move": "Bite",
+            "level": 26
+        }, {
+            "Move": "Tail Whip",
+            "level": 31
+        }, {
+            "Move": "Mega Punch",
+            "level": 36
+        }, {
+            "Move": "Leer",
+            "level": 41
+        }, {
+            "Move": "Dizzy Punch",
+            "level": 46
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Mega Punch",
+            "level": 1
+        }, {
+            "Move": "Mega Kick",
+            "level": 5
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Bubble Beam",
+            "level": 11
+        }, {
+            "Move": "Water Gun",
+            "level": 12
+        }, {
+            "Move": "Ice Beam",
+            "level": 13
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Counter",
+            "level": 18
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Thunderbolt",
+            "level": 24
+        }, {
+            "Move": "Thunder",
+            "level": 25
+        }, {
+            "Move": "Earthquake",
+            "level": 26
+        }, {
+            "Move": "Fissure",
+            "level": 27
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Fire Blast",
+            "level": 38
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Rock Slide",
+            "level": 48
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Kingler": {
+    "label": "Pincer",
+    "sprite": "water",
+    "info": [
+        "The large pincer has 10000 hp of crushing power. However, its huge size makes it unwieldy to use."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 099,
+    "height": ["4", "3"],
+    "weight": 132.3,
+    "types": ["Water"],
+    "HP": 55,
+    "Attack": 130,
+    "Defense": 115,
+    "Special": 50,
+    "Speed": 75,
+    "moves": {
+        "natural": [{
+            "Move": "Bubble",
+            "level": 1
+        }, {
+            "Move": "Leer",
+            "level": 1
+        }, {
+            "Move": "Vice Grip",
+            "level": 1
+        }, {
+            "Move": "Vice Grip",
+            "level": 20
+        }, {
+            "Move": "Guillotine",
+            "level": 25
+        }, {
+            "Move": "Stomp",
+            "level": 34
+        }, {
+            "Move": "Crabhammer",
+            "level": 42
+        }, {
+            "Move": "Harden",
+            "level": 49
+        }],
+        "hm": [{
+            "Move": "Cut",
+            "level": 1
+        }, {
+            "Move": "Surf",
+            "level": 3
+        }, {
+            "Move": "Strength",
+            "level": 4
+        }],
+        "tm": [{
+            "Move": "Swords Dance",
+            "level": 3
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Bubble Beam",
+            "level": 11
+        }, {
+            "Move": "Water Gun",
+            "level": 12
+        }, {
+            "Move": "Ice Beam",
+            "level": 13
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Koffing": {
+    "label": "Poison Gas",
+    "sprite": "water",
+    "info": [
+        "Because it stores several kinds of toxic gases in its body, it is prone to exploding without warning."
+    ],
+    "evolvesInto": "Weezing",
+    "evolvesVia": "Level 35",
+    "number": 109,
+    "height": ["2", "0"],
+    "weight": 2.2,
+    "types": ["Poison"],
+    "HP": 40,
+    "Attack": 65,
+    "Defense": 95,
+    "Special": 60,
+    "Speed": 35,
+    "moves": {
+        "natural": [{
+            "Move": "Smog",
+            "level": 1
+        }, {
+            "Move": "Tackle",
+            "level": 1
+        }, {
+            "Move": "Sludge",
+            "level": 32
+        }, {
+            "Move": "Smokescreen",
+            "level": 37
+        }, {
+            "Move": "Self-Destruct",
+            "level": 40
+        }, {
+            "Move": "Haze",
+            "level": 45
+        }, {
+            "Move": "Explosion",
+            "level": 48
+        }],
+        "hm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Thunderbolt",
+            "level": 24
+        }, {
+            "Move": "Thunder",
+            "level": 25
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Self-Destruct",
+            "level": 36
+        }, {
+            "Move": "Fire Blast",
+            "level": 38
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Explosion",
+            "level": 47
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }],
+        "tm": [{
+            "Move": "Smog",
+            "level": 1
+        }, {
+            "Move": "Tackle",
+            "level": 1
+        }, {
+            "Move": "Sludge",
+            "level": 32
+        }, {
+            "Move": "Smokescreen",
+            "level": 37
+        }, {
+            "Move": "Self-Destruct",
+            "level": 40
+        }, {
+            "Move": "Haze",
+            "level": 45
+        }, {
+            "Move": "Explosion",
+            "level": 48
+        }]
+    }
+}, "Krabby": {
+    "label": "River Crab",
+    "sprite": "water",
+    "info": [
+        "Its pincers are not only powerful weapons, they are used for balance when walking sideways."
+    ],
+    "evolvesInto": "Kingler",
+    "evolvesVia": "Level 28",
+    "number": 098,
+    "height": ["1", "4"],
+    "weight": 14.3,
+    "types": ["Water"],
+    "HP": 30,
+    "Attack": 105,
+    "Defense": 90,
+    "Special": 25,
+    "Speed": 50,
+    "moves": {
+        "natural": [{
+            "Move": "Bubble",
+            "level": 1
+        }, {
+            "Move": "Leer",
+            "level": 1
+        }, {
+            "Move": "Vice Grip",
+            "level": 20
+        }, {
+            "Move": "Guillotine",
+            "level": 25
+        }, {
+            "Move": "Stomp",
+            "level": 30
+        }, {
+            "Move": "Crabhammer",
+            "level": 35
+        }, {
+            "Move": "Harden",
+            "level": 40
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Swords Dance",
+            "level": 3
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Bubble Beam",
+            "level": 11
+        }, {
+            "Move": "Water Gun",
+            "level": 12
+        }, {
+            "Move": "Ice Beam",
+            "level": 13
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Lapras": {
+    "label": "Transport",
+    "sprite": "water",
+    "info": [
+        "A POKÃ©MON that has been overhunted almost to extinction. It can ferry people across the water."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 131,
+    "height": ["8", "2"],
+    "weight": 485,
+    "types": ["Water", "Ice"],
+    "HP": 130,
+    "Attack": 85,
+    "Defense": 80,
+    "Special": 85,
+    "Speed": 60,
+    "moves": {
+        "natural": [{
+            "Move": "Growl",
+            "level": 1
+        }, {
+            "Move": "Water Gun",
+            "level": 1
+        }, {
+            "Move": "Sing",
+            "level": 16
+        }, {
+            "Move": "Mist",
+            "level": 20
+        }, {
+            "Move": "Body Slam",
+            "level": 25
+        }, {
+            "Move": "Confuse Ray",
+            "level": 31
+        }, {
+            "Move": "Ice Beam",
+            "level": 38
+        }, {
+            "Move": "Hydro Pump",
+            "level": 46
+        }],
+        "hm": [{
+            "Move": "Surf",
+            "level": 3
+        }, {
+            "Move": "Strength",
+            "level": 4
+        }],
+        "tm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Horn Drill",
+            "level": 7
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Bubble Beam",
+            "level": 11
+        }, {
+            "Move": "Water Gun",
+            "level": 12
+        }, {
+            "Move": "Ice Beam",
+            "level": 13
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Solar Beam",
+            "level": 22
+        }, {
+            "Move": "Dragon Rage",
+            "level": 23
+        }, {
+            "Move": "Thunderbolt",
+            "level": 24
+        }, {
+            "Move": "Thunder",
+            "level": 25
+        }, {
+            "Move": "Psychic",
+            "level": 29
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Psywave",
+            "level": 46
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Lickitung": {
+    "label": "Licking",
+    "sprite": "water",
+    "info": [
+        "Its tongue can be extended like a chameleon's. It leaves a tingling sensation when it licks enemies."
+    ],
+    "evolvesInto": "Lickilicky",
+    "evolvesVia": "after Rolloutlearned",
+    "number": 108,
+    "height": ["3", "11"],
+    "weight": 144.4,
+    "types": ["Normal"],
+    "HP": 90,
+    "Attack": 55,
+    "Defense": 75,
+    "Special": 60,
+    "Speed": 30,
+    "moves": {
+        "natural": [{
+            "Move": "Supersonic",
+            "level": 1
+        }, {
+            "Move": "Wrap",
+            "level": 1
+        }, {
+            "Move": "Stomp",
+            "level": 7
+        }, {
+            "Move": "Disable",
+            "level": 15
+        }, {
+            "Move": "Defense Curl",
+            "level": 23
+        }, {
+            "Move": "Slam",
+            "level": 31
+        }, {
+            "Move": "Screech",
+            "level": 39
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Mega Punch",
+            "level": 1
+        }, {
+            "Move": "Swords Dance",
+            "level": 3
+        }, {
+            "Move": "Mega Kick",
+            "level": 5
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Bubble Beam",
+            "level": 11
+        }, {
+            "Move": "Water Gun",
+            "level": 12
+        }, {
+            "Move": "Ice Beam",
+            "level": 13
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Counter",
+            "level": 18
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Thunderbolt",
+            "level": 24
+        }, {
+            "Move": "Thunder",
+            "level": 25
+        }, {
+            "Move": "Earthquake",
+            "level": 26
+        }, {
+            "Move": "Fissure",
+            "level": 27
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Fire Blast",
+            "level": 38
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Machamp": {
+    "label": "Superpower",
+    "sprite": "water",
+    "info": [
+        "Using its heavy muscles, it throws powerful punches that can send the victim clear over the horizon."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 068,
+    "height": ["5", "3"],
+    "weight": 286.6,
+    "types": ["Fighting"],
+    "HP": 90,
+    "Attack": 130,
+    "Defense": 80,
+    "Special": 65,
+    "Speed": 55,
+    "moves": {
+        "natural": [{
+            "Move": "Karate Chop",
+            "level": 1
+        }, {
+            "Move": "Leer",
+            "level": 1
+        }, {
+            "Move": "Low Kick",
+            "level": 1
+        }, {
+            "Move": "Low Kick",
+            "level": 20
+        }, {
+            "Move": "Leer",
+            "level": 25
+        }, {
+            "Move": "Focus Energy",
+            "level": 36
+        }, {
+            "Move": "Seismic Toss",
+            "level": 44
+        }, {
+            "Move": "Submission",
+            "level": 52
+        }],
+        "hm": [{
+            "Move": "Strength",
+            "level": 4
+        }],
+        "tm": [{
+            "Move": "Mega Punch",
+            "level": 1
+        }, {
+            "Move": "Mega Kick",
+            "level": 5
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Counter",
+            "level": 18
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Earthquake",
+            "level": 26
+        }, {
+            "Move": "Fissure",
+            "level": 27
+        }, {
+            "Move": "Dig",
+            "level": 28
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Metronome",
+            "level": 35
+        }, {
+            "Move": "Fire Blast",
+            "level": 38
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Rock Slide",
+            "level": 48
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Machoke": {
+    "label": "Superpower",
+    "sprite": "water",
+    "info": [
+        "Its muscular body is so powerful, it must wear a power save belt to be able to regulate its motions."
+    ],
+    "evolvesInto": "Machamp",
+    "evolvesVia": "Trade",
+    "number": 067,
+    "height": ["4", "11"],
+    "weight": 155.4,
+    "types": ["Fighting"],
+    "HP": 80,
+    "Attack": 100,
+    "Defense": 70,
+    "Special": 50,
+    "Speed": 45,
+    "moves": {
+        "natural": [{
+            "Move": "Karate Chop",
+            "level": 1
+        }, {
+            "Move": "Leer",
+            "level": 1
+        }, {
+            "Move": "Low Kick",
+            "level": 1
+        }, {
+            "Move": "Low Kick",
+            "level": 20
+        }, {
+            "Move": "Leer",
+            "level": 25
+        }, {
+            "Move": "Focus Energy",
+            "level": 36
+        }, {
+            "Move": "Seismic Toss",
+            "level": 44
+        }, {
+            "Move": "Submission",
+            "level": 52
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Mega Punch",
+            "level": 1
+        }, {
+            "Move": "Mega Kick",
+            "level": 5
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Counter",
+            "level": 18
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Earthquake",
+            "level": 26
+        }, {
+            "Move": "Fissure",
+            "level": 27
+        }, {
+            "Move": "Dig",
+            "level": 28
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Metronome",
+            "level": 35
+        }, {
+            "Move": "Fire Blast",
+            "level": 38
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Rock Slide",
+            "level": 48
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Machop": {
+    "label": "Superpower",
+    "sprite": "water",
+    "info": [
+        "Loves to build its muscles. It trains in all styles of martial arts to become even stronger."
+    ],
+    "evolvesInto": "Machoke",
+    "evolvesVia": "Level 28",
+    "number": 066,
+    "height": ["2", "7"],
+    "weight": 43,
+    "types": ["Fighting"],
+    "HP": 70,
+    "Attack": 80,
+    "Defense": 50,
+    "Special": 35,
+    "Speed": 35,
+    "moves": {
+        "natural": [{
+            "Move": "Karate Chop",
+            "level": 1
+        }, {
+            "Move": "Low Kick",
+            "level": 20
+        }, {
+            "Move": "Leer",
+            "level": 25
+        }, {
+            "Move": "Focus Energy",
+            "level": 32
+        }, {
+            "Move": "Seismic Toss",
+            "level": 39
+        }, {
+            "Move": "Submission",
+            "level": 46
+        }],
+        "hm": [{
+            "Move": "Strength",
+            "level": 4
+        }],
+        "tm": [{
+            "Move": "Mega Punch",
+            "level": 1
+        }, {
+            "Move": "Mega Kick",
+            "level": 5
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Counter",
+            "level": 18
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Earthquake",
+            "level": 26
+        }, {
+            "Move": "Fissure",
+            "level": 27
+        }, {
+            "Move": "Dig",
+            "level": 28
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Metronome",
+            "level": 35
+        }, {
+            "Move": "Fire Blast",
+            "level": 38
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Rock Slide",
+            "level": 48
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Magikarp": {
+    "label": "Fish",
+    "sprite": "water",
+    "info": [
+        "In the distant past, it was somewhat stronger than the horribly weak descendants that exist today."
+    ],
+    "evolvesInto": "Gyarados",
+    "evolvesVia": "Level 20",
+    "number": 129,
+    "height": ["2", "11"],
+    "weight": 22,
+    "types": ["Water"],
+    "HP": 20,
+    "Attack": 10,
+    "Defense": 55,
+    "Special": 15,
+    "Speed": 80,
+    "moves": {
+        "natural": [{
+            "Move": "Splash",
+            "level": 1
+        }, {
+            "Move": "Tackle",
+            "level": 15
+        }],
+        "hm": [],
+        "tm": []
+    }
+}, "Magmar": {
+    "label": "Spitfire",
+    "sprite": "water",
+    "info": [
+        "Its body always burns with an orange glow that enables it to hide perfectly among flames."
+    ],
+    "evolvesInto": "Magmortar",
+    "evolvesVia": "trade holdingMagmarizer",
+    "number": 126,
+    "height": ["4", "3"],
+    "weight": 98.1,
+    "types": ["Fire"],
+    "HP": 65,
+    "Attack": 95,
+    "Defense": 57,
+    "Special": 100,
+    "Speed": 93,
+    "moves": {
+        "natural": [{
+            "Move": "Ember",
+            "level": 1
+        }, {
+            "Move": "Leer",
+            "level": 36
+        }, {
+            "Move": "Confuse Ray",
+            "level": 39
+        }, {
+            "Move": "Fire Punch",
+            "level": 43
+        }, {
+            "Move": "Smokescreen",
+            "level": 48
+        }, {
+            "Move": "Smog",
+            "level": 52
+        }, {
+            "Move": "Flamethrower",
+            "level": 55
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Mega Punch",
+            "level": 1
+        }, {
+            "Move": "Mega Kick",
+            "level": 5
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Counter",
+            "level": 18
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Psychic",
+            "level": 29
+        }, {
+            "Move": "Teleport",
+            "level": 30
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Metronome",
+            "level": 35
+        }, {
+            "Move": "Fire Blast",
+            "level": 38
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Psywave",
+            "level": 46
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Magnemite": {
+    "label": "Magnet",
+    "sprite": "water",
+    "info": [
+        "Uses anti-gravity to stay suspended. Appears without warning and uses THUNDER WAVE and similar moves."
+    ],
+    "evolvesInto": "Magneton",
+    "evolvesVia": "Level 30",
+    "number": 081,
+    "height": ["1", "0"],
+    "weight": 13.2,
+    "types": ["Electric", "Steel"],
+    "HP": 25,
+    "Attack": 35,
+    "Defense": 70,
+    "Special": 95,
+    "Speed": 45,
+    "moves": {
+        "natural": [{
+            "Move": "Tackle",
+            "level": 1
+        }, {
+            "Move": "Sonic Boom",
+            "level": 21
+        }, {
+            "Move": "Thunder Shock",
+            "level": 25
+        }, {
+            "Move": "Supersonic",
+            "level": 29
+        }, {
+            "Move": "Thunder Wave",
+            "level": 35
+        }, {
+            "Move": "Swift",
+            "level": 41
+        }, {
+            "Move": "Screech",
+            "level": 47
+        }],
+        "hm": [{
+            "Move": "Flash",
+            "level": 5
+        }],
+        "tm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Thunderbolt",
+            "level": 24
+        }, {
+            "Move": "Thunder",
+            "level": 25
+        }, {
+            "Move": "Teleport",
+            "level": 30
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Thunder Wave",
+            "level": 45
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Magneton": {
+    "label": "Magnet",
+    "sprite": "water",
+    "info": [
+        "Formed by several MAGNEMITEs linked together. They frequently appear when sunspots flare up."
+    ],
+    "evolvesInto": "Magnezone",
+    "evolvesVia": "in a Magnetic Field area",
+    "number": 082,
+    "height": ["3", "3"],
+    "weight": 132.3,
+    "types": ["Electric", "Steel"],
+    "HP": 50,
+    "Attack": 60,
+    "Defense": 95,
+    "Special": 120,
+    "Speed": 70,
+    "moves": {
+        "natural": [{
+            "Move": "Sonic Boom",
+            "level": 1
+        }, {
+            "Move": "Tackle",
+            "level": 1
+        }, {
+            "Move": "Thunder Shock",
+            "level": 1
+        }, {
+            "Move": "Sonic Boom",
+            "level": 21
+        }, {
+            "Move": "Thunder Shock",
+            "level": 25
+        }, {
+            "Move": "Supersonic",
+            "level": 29
+        }, {
+            "Move": "Thunder Wave",
+            "level": 38
+        }, {
+            "Move": "Swift",
+            "level": 46
+        }, {
+            "Move": "Screech",
+            "level": 54
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Thunderbolt",
+            "level": 24
+        }, {
+            "Move": "Thunder",
+            "level": 25
+        }, {
+            "Move": "Teleport",
+            "level": 30
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Thunder Wave",
+            "level": 45
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Mankey": {
+    "label": "Pig Monkey",
+    "sprite": "water",
+    "info": [
+        "Extremely quick to anger. It could be docile one moment then thrashing away the next instant."
+    ],
+    "evolvesInto": "Primeape",
+    "evolvesVia": "Level 28",
+    "number": 056,
+    "height": ["1", "8"],
+    "weight": 61.7,
+    "types": ["Fighting"],
+    "HP": 40,
+    "Attack": 80,
+    "Defense": 35,
+    "Special": 35,
+    "Speed": 70,
+    "moves": {
+        "natural": [{
+            "Move": "Leer",
+            "level": 1
+        }, {
+            "Move": "Scratch",
+            "level": 1
+        }, {
+            "Move": "Karate Chop",
+            "level": 15
+        }, {
+            "Move": "Fury Swipes",
+            "level": 21
+        }, {
+            "Move": "Focus Energy",
+            "level": 27
+        }, {
+            "Move": "Seismic Toss",
+            "level": 33
+        }, {
+            "Move": "Thrash",
+            "level": 39
+        }],
+        "hm": [{
+            "Move": "Strength",
+            "level": 4
+        }],
+        "tm": [{
+            "Move": "Mega Punch",
+            "level": 1
+        }, {
+            "Move": "Mega Kick",
+            "level": 5
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Pay Day",
+            "level": 16
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Counter",
+            "level": 18
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Thunderbolt",
+            "level": 24
+        }, {
+            "Move": "Thunder",
+            "level": 25
+        }, {
+            "Move": "Dig",
+            "level": 28
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Metronome",
+            "level": 35
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Rock Slide",
+            "level": 48
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Marowak": {
+    "label": "Bone Keeper",
+    "sprite": "water",
+    "info": [
+        "The bone it holds is its key weapon. It throws the bone skillfully like a boomerang to KO targets."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 105,
+    "height": ["3", "3"],
+    "weight": 99.2,
+    "types": ["Ground"],
+    "HP": 60,
+    "Attack": 80,
+    "Defense": 110,
+    "Special": 50,
+    "Speed": 45,
+    "moves": {
+        "natural": [{
+            "Move": "Bone Club",
+            "level": 1
+        }, {
+            "Move": "Focus Energy",
+            "level": 1
+        }, {
+            "Move": "Growl",
+            "level": 1
+        }, {
+            "Move": "Leer",
+            "level": 1
+        }, {
+            "Move": "Leer",
+            "level": 25
+        }, {
+            "Move": "Focus Energy",
+            "level": 33
+        }, {
+            "Move": "Thrash",
+            "level": 41
+        }, {
+            "Move": "Bonemerang",
+            "level": 48
+        }, {
+            "Move": "Rage",
+            "level": 55
+        }],
+        "hm": [{
+            "Move": "Strength",
+            "level": 4
+        }],
+        "tm": [{
+            "Move": "Mega Punch",
+            "level": 1
+        }, {
+            "Move": "Mega Kick",
+            "level": 5
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Bubble Beam",
+            "level": 11
+        }, {
+            "Move": "Water Gun",
+            "level": 12
+        }, {
+            "Move": "Ice Beam",
+            "level": 13
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Counter",
+            "level": 18
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Earthquake",
+            "level": 26
+        }, {
+            "Move": "Fissure",
+            "level": 27
+        }, {
+            "Move": "Dig",
+            "level": 28
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Fire Blast",
+            "level": 38
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Meowth": {
+    "label": "Scratch Cat",
+    "sprite": "water",
+    "info": [
+        "Adores circular objects. Wanders the streets on a nightly basis to look for dropped loose change."
+    ],
+    "evolvesInto": "Persian",
+    "evolvesVia": "Level 28",
+    "number": 052,
+    "height": ["1", "4"],
+    "weight": 9.3,
+    "types": ["Normal"],
+    "HP": 40,
+    "Attack": 45,
+    "Defense": 35,
+    "Special": 40,
+    "Speed": 90,
+    "moves": {
+        "natural": [{
+            "Move": "Growl",
+            "level": 1
+        }, {
+            "Move": "Scratch",
+            "level": 1
+        }, {
+            "Move": "Bite",
+            "level": 12
+        }, {
+            "Move": "Pay Day",
+            "level": 17
+        }, {
+            "Move": "Screech",
+            "level": 24
+        }, {
+            "Move": "Fury Swipes",
+            "level": 33
+        }, {
+            "Move": "Slash",
+            "level": 44
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Growl",
+            "level": 1
+        }, {
+            "Move": "Scratch",
+            "level": 1
+        }, {
+            "Move": "Bite",
+            "level": 12
+        }, {
+            "Move": "Pay Day",
+            "level": 17
+        }, {
+            "Move": "Screech",
+            "level": 24
+        }, {
+            "Move": "Fury Swipes",
+            "level": 33
+        }, {
+            "Move": "Slash",
+            "level": 44
+        }]
+    }
+}, "Metapod": {
+    "label": "Cocoon",
+    "sprite": "water",
+    "info": [
+        "This POKÃ©MON is vulnerable to attack while its shell is soft, exposing its weak and tender body."
+    ],
+    "evolvesInto": "Butterfree",
+    "evolvesVia": "Level 10",
+    "number": 011,
+    "height": ["2", "4"],
+    "weight": 21.8,
+    "types": ["Bug"],
+    "HP": 50,
+    "Attack": 20,
+    "Defense": 55,
+    "Special": 25,
+    "Speed": 30,
+    "moves": {
+        "natural": [{
+            "Move": "Harden",
+            "level": 1
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Harden",
+            "level": 1
+        }, {
+            "Move": "Harden",
+            "level": 7
+        }]
+    }
+}, "Mew": {
+    "label": "New Species",
+    "sprite": "water",
+    "info": [
+        "So rare that it is still said to be a mirage by many experts. Only a few people have seen it worldwide."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 151,
+    "height": ["1", "4"],
+    "weight": 8.8,
+    "types": ["Psychic"],
+    "HP": 100,
+    "Attack": 100,
+    "Defense": 100,
+    "Special": 100,
+    "Speed": 100,
+    "moves": {
+        "natural": [{
+            "Move": "Pound",
+            "level": 1
+        }, {
+            "Move": "Transform",
+            "level": 10
+        }, {
+            "Move": "Mega Punch",
+            "level": 20
+        }, {
+            "Move": "Metronome",
+            "level": 30
+        }, {
+            "Move": "Psychic",
+            "level": 40
+        }],
+        "hm": [{
+            "Move": "Cut",
+            "level": 1
+        }, {
+            "Move": "Fly",
+            "level": 2
+        }, {
+            "Move": "Surf",
+            "level": 3
+        }, {
+            "Move": "Strength",
+            "level": 4
+        }, {
+            "Move": "Flash",
+            "level": 5
+        }],
+        "tm": [{
+            "Move": "Mega Punch",
+            "level": 1
+        }, {
+            "Move": "Razor Wind",
+            "level": 2
+        }, {
+            "Move": "Swords Dance",
+            "level": 3
+        }, {
+            "Move": "Whirlwind",
+            "level": 4
+        }, {
+            "Move": "Mega Kick",
+            "level": 5
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Horn Drill",
+            "level": 7
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Bubble Beam",
+            "level": 11
+        }, {
+            "Move": "Water Gun",
+            "level": 12
+        }, {
+            "Move": "Ice Beam",
+            "level": 13
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Pay Day",
+            "level": 16
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Counter",
+            "level": 18
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mega Drain",
+            "level": 21
+        }, {
+            "Move": "Solar Beam",
+            "level": 22
+        }, {
+            "Move": "Dragon Rage",
+            "level": 23
+        }, {
+            "Move": "Thunderbolt",
+            "level": 24
+        }, {
+            "Move": "Thunder",
+            "level": 25
+        }, {
+            "Move": "Earthquake",
+            "level": 26
+        }, {
+            "Move": "Fissure",
+            "level": 27
+        }, {
+            "Move": "Dig",
+            "level": 28
+        }, {
+            "Move": "Psychic",
+            "level": 29
+        }, {
+            "Move": "Teleport",
+            "level": 30
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Metronome",
+            "level": 35
+        }, {
+            "Move": "Self-Destruct",
+            "level": 36
+        }, {
+            "Move": "Egg Bomb",
+            "level": 37
+        }, {
+            "Move": "Fire Blast",
+            "level": 38
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Soft-Boiled",
+            "level": 41
+        }, {
+            "Move": "Dream Eater",
+            "level": 42
+        }, {
+            "Move": "Sky Attack",
+            "level": 43
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Thunder Wave",
+            "level": 45
+        }, {
+            "Move": "Psywave",
+            "level": 46
+        }, {
+            "Move": "Explosion",
+            "level": 47
+        }, {
+            "Move": "Rock Slide",
+            "level": 48
+        }, {
+            "Move": "Tri Attack",
+            "level": 49
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Mewtwo": {
+    "label": "Genetic",
+    "sprite": "water",
+    "info": [
+        "It was created by a scientist after years of horrific gene splicing and DNA engineering experiments."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 150,
+    "height": ["6", "7"],
+    "weight": 269,
+    "types": ["Psychic"],
+    "HP": 106,
+    "Attack": 110,
+    "Defense": 90,
+    "Special": 154,
+    "Speed": 130,
+    "moves": {
+        "natural": [{
+            "Move": "Confusion",
+            "level": 1
+        }, {
+            "Move": "Disable",
+            "level": 1
+        }, {
+            "Move": "Psychic",
+            "level": 1
+        }, {
+            "Move": "Swift",
+            "level": 1
+        }, {
+            "Move": "Barrier",
+            "level": 63
+        }, {
+            "Move": "Psychic",
+            "level": 66
+        }, {
+            "Move": "Recover",
+            "level": 70
+        }, {
+            "Move": "Mist",
+            "level": 75
+        }, {
+            "Move": "Amnesia",
+            "level": 81
+        }],
+        "hm": [{
+            "Move": "Strength",
+            "level": 4
+        }, {
+            "Move": "Flash",
+            "level": 5
+        }],
+        "tm": [{
+            "Move": "Mega Punch",
+            "level": 1
+        }, {
+            "Move": "Mega Kick",
+            "level": 5
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Bubble Beam",
+            "level": 11
+        }, {
+            "Move": "Water Gun",
+            "level": 12
+        }, {
+            "Move": "Ice Beam",
+            "level": 13
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Pay Day",
+            "level": 16
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Counter",
+            "level": 18
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Solar Beam",
+            "level": 22
+        }, {
+            "Move": "Thunderbolt",
+            "level": 24
+        }, {
+            "Move": "Thunder",
+            "level": 25
+        }, {
+            "Move": "Psychic",
+            "level": 29
+        }, {
+            "Move": "Teleport",
+            "level": 30
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Metronome",
+            "level": 35
+        }, {
+            "Move": "Self-Destruct",
+            "level": 36
+        }, {
+            "Move": "Fire Blast",
+            "level": 38
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Thunder Wave",
+            "level": 45
+        }, {
+            "Move": "Psywave",
+            "level": 46
+        }, {
+            "Move": "Tri Attack",
+            "level": 49
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Moltres": {
+    "label": "Flame",
+    "sprite": "water",
+    "info": [
+        "Known as the legendary bird of fire. Every flap of its wings creates a dazzling flash of flames."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 146,
+    "height": ["6", "7"],
+    "weight": 132.3,
+    "types": ["Fire", "Flying"],
+    "HP": 90,
+    "Attack": 100,
+    "Defense": 90,
+    "Special": 125,
+    "Speed": 90,
+    "moves": {
+        "natural": [{
+            "Move": "Fire Spin",
+            "level": 1
+        }, {
+            "Move": "Peck",
+            "level": 1
+        }, {
+            "Move": "Leer",
+            "level": 51
+        }, {
+            "Move": "Agility",
+            "level": 55
+        }, {
+            "Move": "Sky Attack",
+            "level": 60
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Razor Wind",
+            "level": 2
+        }, {
+            "Move": "Whirlwind",
+            "level": 4
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Fire Blast",
+            "level": 38
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Sky Attack",
+            "level": 43
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Mr-mime": {
+    "label": "Barrier",
+    "sprite": "water",
+    "info": [
+        "If interrupted while it is miming, it will slap around the offender with its broad hands."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 122,
+    "height": ["4", "3"],
+    "weight": 120.2,
+    "types": ["Psychic", "Fairy"],
+    "HP": 40,
+    "Attack": 45,
+    "Defense": 65,
+    "Special": 100,
+    "Speed": 90,
+    "moves": {
+        "natural": [{
+            "Move": "Barrier",
+            "level": 1
+        }, {
+            "Move": "Confusion",
+            "level": 1
+        }, {
+            "Move": "Confusion",
+            "level": 15
+        }, {
+            "Move": "Light Screen",
+            "level": 23
+        }, {
+            "Move": "Double Slap",
+            "level": 31
+        }, {
+            "Move": "Meditate",
+            "level": 39
+        }, {
+            "Move": "Substitute",
+            "level": 47
+        }],
+        "hm": [{
+            "Move": "Flash",
+            "level": 5
+        }],
+        "tm": [{
+            "Move": "Mega Punch",
+            "level": 1
+        }, {
+            "Move": "Mega Kick",
+            "level": 5
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Counter",
+            "level": 18
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Solar Beam",
+            "level": 22
+        }, {
+            "Move": "Thunderbolt",
+            "level": 24
+        }, {
+            "Move": "Thunder",
+            "level": 25
+        }, {
+            "Move": "Psychic",
+            "level": 29
+        }, {
+            "Move": "Teleport",
+            "level": 30
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Metronome",
+            "level": 35
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Thunder Wave",
+            "level": 45
+        }, {
+            "Move": "Psywave",
+            "level": 46
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Muk": {
+    "label": "Sludge",
+    "sprite": "water",
+    "info": [
+        "Thickly covered with a filthy, vile sludge. It is so toxic, even its footprints contain poison."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 089,
+    "height": ["3", "11"],
+    "weight": 66.1,
+    "types": ["Poison"],
+    "HP": 105,
+    "Attack": 105,
+    "Defense": 75,
+    "Special": 65,
+    "Speed": 50,
+    "moves": {
+        "natural": [{
+            "Move": "Disable",
+            "level": 1
+        }, {
+            "Move": "Poison Gas",
+            "level": 1
+        }, {
+            "Move": "Pound",
+            "level": 1
+        }, {
+            "Move": "Poison Gas",
+            "level": 30
+        }, {
+            "Move": "Minimize",
+            "level": 33
+        }, {
+            "Move": "Sludge",
+            "level": 37
+        }, {
+            "Move": "Harden",
+            "level": 45
+        }, {
+            "Move": "Screech",
+            "level": 53
+        }, {
+            "Move": "Acid Armor",
+            "level": 60
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Disable",
+            "level": 1
+        }, {
+            "Move": "Poison Gas",
+            "level": 1
+        }, {
+            "Move": "Pound",
+            "level": 1
+        }, {
+            "Move": "Poison Gas",
+            "level": 30
+        }, {
+            "Move": "Minimize",
+            "level": 33
+        }, {
+            "Move": "Sludge",
+            "level": 37
+        }, {
+            "Move": "Harden",
+            "level": 45
+        }, {
+            "Move": "Screech",
+            "level": 53
+        }, {
+            "Move": "Acid Armor",
+            "level": 60
+        }]
+    }
+}, "Nidoking": {
+    "label": "Drill",
+    "sprite": "water",
+    "info": [
+        "It uses its powerful tail in battle to smash, constrict, then break the prey's bones."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 034,
+    "height": ["4", "7"],
+    "weight": 136.7,
+    "types": ["Poison", "Ground"],
+    "HP": 81,
+    "Attack": 102,
+    "Defense": 77,
+    "Special": 85,
+    "Speed": 85,
+    "moves": {
+        "natural": [{
+            "Move": "Horn Attack",
+            "level": 1
+        }, {
+            "Move": "Poison Sting",
+            "level": 1
+        }, {
+            "Move": "Tackle",
+            "level": 1
+        }, {
+            "Move": "Thrash",
+            "level": 1
+        }, {
+            "Move": "Horn Attack",
+            "level": 8
+        }, {
+            "Move": "Poison Sting",
+            "level": 14
+        }, {
+            "Move": "Thrash",
+            "level": 23
+        }],
+        "hm": [{
+            "Move": "Surf",
+            "level": 3
+        }, {
+            "Move": "Strength",
+            "level": 4
+        }],
+        "tm": [{
+            "Move": "Surf",
+            "level": 3
+        }, {
+            "Move": "Strength",
+            "level": 4
+        }]
+    }
+}, "Nidoqueen": {
+    "label": "Drill",
+    "sprite": "water",
+    "info": [
+        "Its hard scales provide strong protection. It uses its hefty bulk to execute powerful moves."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 031,
+    "height": ["4", "3"],
+    "weight": 132.3,
+    "types": ["Poison", "Ground"],
+    "HP": 90,
+    "Attack": 92,
+    "Defense": 87,
+    "Special": 75,
+    "Speed": 76,
+    "moves": {
+        "natural": [{
+            "Move": "Body Slam",
+            "level": 1
+        }, {
+            "Move": "Scratch",
+            "level": 1
+        }, {
+            "Move": "Tackle",
+            "level": 1
+        }, {
+            "Move": "Tail Whip",
+            "level": 1
+        }, {
+            "Move": "Scratch",
+            "level": 8
+        }, {
+            "Move": "Poison Sting",
+            "level": 14
+        }, {
+            "Move": "Body Slam",
+            "level": 23
+        }],
+        "hm": [{
+            "Move": "Surf",
+            "level": 3
+        }, {
+            "Move": "Strength",
+            "level": 4
+        }],
+        "tm": [{
+            "Move": "Surf",
+            "level": 3
+        }, {
+            "Move": "Strength",
+            "level": 4
+        }]
+    }
+}, "Nidoran-f": {
+    "label": "Poison Pin",
+    "sprite": "water",
+    "info": [
+        "Although small, its venomous barbs render this POKÃ©MON dangerous. The female has smaller horns."
+    ],
+    "evolvesInto": "Nidorina",
+    "evolvesVia": "Level 16",
+    "number": 029,
+    "height": ["1", "4"],
+    "weight": 15.4,
+    "types": ["Poison"],
+    "HP": 55,
+    "Attack": 47,
+    "Defense": 52,
+    "Special": 40,
+    "Speed": 41,
+    "moves": {
+        "natural": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Thunderbolt",
+            "level": 24
+        }, {
+            "Move": "Thunder",
+            "level": 25
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }],
+        "hm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Thunderbolt",
+            "level": 24
+        }, {
+            "Move": "Thunder",
+            "level": 25
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }],
+        "tm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Thunderbolt",
+            "level": 24
+        }, {
+            "Move": "Thunder",
+            "level": 25
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Nidoran-m": {
+    "label": "Poison Pin",
+    "sprite": "water",
+    "info": [
+        "Stiffens its ears to sense danger. The larger its horns, the more powerful its secreted venom."
+    ],
+    "evolvesInto": "Nidorino",
+    "evolvesVia": "Level 16",
+    "number": 032,
+    "height": ["1", "8"],
+    "weight": 19.8,
+    "types": ["Poison"],
+    "HP": 46,
+    "Attack": 57,
+    "Defense": 40,
+    "Special": 40,
+    "Speed": 50,
+    "moves": {
+        "natural": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Horn Drill",
+            "level": 7
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Thunderbolt",
+            "level": 24
+        }, {
+            "Move": "Thunder",
+            "level": 25
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }],
+        "hm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Horn Drill",
+            "level": 7
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Thunderbolt",
+            "level": 24
+        }, {
+            "Move": "Thunder",
+            "level": 25
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }],
+        "tm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Horn Drill",
+            "level": 7
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Thunderbolt",
+            "level": 24
+        }, {
+            "Move": "Thunder",
+            "level": 25
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Nidorina": {
+    "label": "Poison Pin",
+    "sprite": "water",
+    "info": [
+        "The female's horn develops slowly. Prefers physical attacks such as clawing and biting."
+    ],
+    "evolvesInto": "Nidoqueen",
+    "evolvesVia": "use Moon Stone",
+    "number": 030,
+    "height": ["2", "7"],
+    "weight": 44.1,
+    "types": ["Poison"],
+    "HP": 70,
+    "Attack": 62,
+    "Defense": 67,
+    "Special": 55,
+    "Speed": 56,
+    "moves": {
+        "natural": [{
+            "Move": "Growl",
+            "level": 1
+        }, {
+            "Move": "Scratch",
+            "level": 1
+        }, {
+            "Move": "Tackle",
+            "level": 1
+        }, {
+            "Move": "Scratch",
+            "level": 8
+        }, {
+            "Move": "Poison Sting",
+            "level": 14
+        }, {
+            "Move": "Tail Whip",
+            "level": 23
+        }, {
+            "Move": "Bite",
+            "level": 32
+        }, {
+            "Move": "Fury Swipes",
+            "level": 41
+        }, {
+            "Move": "Double Kick",
+            "level": 50
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Growl",
+            "level": 1
+        }, {
+            "Move": "Scratch",
+            "level": 1
+        }, {
+            "Move": "Tackle",
+            "level": 1
+        }, {
+            "Move": "Scratch",
+            "level": 8
+        }, {
+            "Move": "Double Kick",
+            "level": 12
+        }, {
+            "Move": "Poison Sting",
+            "level": 19
+        }, {
+            "Move": "Tail Whip",
+            "level": 27
+        }, {
+            "Move": "Bite",
+            "level": 36
+        }, {
+            "Move": "Fury Swipes",
+            "level": 46
+        }]
+    }
+}, "Nidorino": {
+    "label": "Poison Pin",
+    "sprite": "water",
+    "info": [
+        "An aggressive POKÃ©MON that is quick to attack. The horn on its head secretes a powerful venom."
+    ],
+    "evolvesInto": "Nidoking",
+    "evolvesVia": "use Moon Stone",
+    "number": 033,
+    "height": ["2", "11"],
+    "weight": 43,
+    "types": ["Poison"],
+    "HP": 61,
+    "Attack": 72,
+    "Defense": 57,
+    "Special": 55,
+    "Speed": 65,
+    "moves": {
+        "natural": [{
+            "Move": "Horn Attack",
+            "level": 1
+        }, {
+            "Move": "Leer",
+            "level": 1
+        }, {
+            "Move": "Tackle",
+            "level": 1
+        }, {
+            "Move": "Horn Attack",
+            "level": 8
+        }, {
+            "Move": "Poison Sting",
+            "level": 14
+        }, {
+            "Move": "Focus Energy",
+            "level": 23
+        }, {
+            "Move": "Fury Attack",
+            "level": 32
+        }, {
+            "Move": "Horn Drill",
+            "level": 41
+        }, {
+            "Move": "Double Kick",
+            "level": 50
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Horn Attack",
+            "level": 1
+        }, {
+            "Move": "Leer",
+            "level": 1
+        }, {
+            "Move": "Tackle",
+            "level": 1
+        }, {
+            "Move": "Horn Attack",
+            "level": 8
+        }, {
+            "Move": "Double Kick",
+            "level": 12
+        }, {
+            "Move": "Poison Sting",
+            "level": 19
+        }, {
+            "Move": "Focus Energy",
+            "level": 27
+        }, {
+            "Move": "Fury Attack",
+            "level": 36
+        }, {
+            "Move": "Horn Drill",
+            "level": 46
+        }]
+    }
+}, "Ninetales": {
+    "label": "Fox",
+    "sprite": "water",
+    "info": [
+        "Very smart and very vengeful. Grabbing one of its many tails could result in a 1000-year curse."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 038,
+    "height": ["3", "7"],
+    "weight": 43.9,
+    "types": ["Fire"],
+    "HP": 73,
+    "Attack": 76,
+    "Defense": 75,
+    "Special": 81,
+    "Speed": 100,
+    "moves": {
+        "natural": [{
+            "Move": "Ember",
+            "level": 1
+        }, {
+            "Move": "Quick Attack",
+            "level": 1
+        }, {
+            "Move": "Roar",
+            "level": 1
+        }, {
+            "Move": "Tail Whip",
+            "level": 1
+        }],
+        "hm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Dig",
+            "level": 28
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Fire Blast",
+            "level": 38
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }],
+        "tm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Dig",
+            "level": 28
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Fire Blast",
+            "level": 38
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Oddish": {
+    "label": "Weed",
+    "sprite": "water",
+    "info": [
+        "During the day, it keeps its face buried in the ground. At night, it wanders around sowing its seeds."
+    ],
+    "evolvesInto": "Gloom",
+    "evolvesVia": "Level 21",
+    "number": 043,
+    "height": ["1", "8"],
+    "weight": 11.9,
+    "types": ["Grass", "Poison"],
+    "HP": 45,
+    "Attack": 50,
+    "Defense": 55,
+    "Special": 75,
+    "Speed": 30,
+    "moves": {
+        "natural": [{
+            "Move": "Absorb",
+            "level": 1
+        }, {
+            "Move": "Poison Powder",
+            "level": 15
+        }, {
+            "Move": "Stun Spore",
+            "level": 17
+        }, {
+            "Move": "Sleep Powder",
+            "level": 19
+        }, {
+            "Move": "Acid",
+            "level": 24
+        }, {
+            "Move": "Petal Dance",
+            "level": 33
+        }, {
+            "Move": "Solar Beam",
+            "level": 46
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Swords Dance",
+            "level": 3
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mega Drain",
+            "level": 21
+        }, {
+            "Move": "Solar Beam",
+            "level": 22
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Omanyte": {
+    "label": "Spiral",
+    "sprite": "water",
+    "info": [
+        "Although long extinct, in rare cases, it can be genetically resurrected from fossils."
+    ],
+    "evolvesInto": "Omastar",
+    "evolvesVia": "Level 40",
+    "number": 138,
+    "height": ["1", "4"],
+    "weight": 16.5,
+    "types": ["Rock", "Water"],
+    "HP": 35,
+    "Attack": 40,
+    "Defense": 100,
+    "Special": 90,
+    "Speed": 35,
+    "moves": {
+        "natural": [{
+            "Move": "Water Gun",
+            "level": 1
+        }, {
+            "Move": "Withdraw",
+            "level": 1
+        }, {
+            "Move": "Horn Attack",
+            "level": 34
+        }, {
+            "Move": "Leer",
+            "level": 39
+        }, {
+            "Move": "Spike Cannon",
+            "level": 46
+        }, {
+            "Move": "Hydro Pump",
+            "level": 53
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Bubble Beam",
+            "level": 11
+        }, {
+            "Move": "Water Gun",
+            "level": 12
+        }, {
+            "Move": "Ice Beam",
+            "level": 13
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Omastar": {
+    "label": "Spiral",
+    "sprite": "water",
+    "info": [
+        "A prehistoric POKÃ©MON that died out when its heavy shell made it impossible to catch prey."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 139,
+    "height": ["3", "3"],
+    "weight": 77.2,
+    "types": ["Rock", "Water"],
+    "HP": 70,
+    "Attack": 60,
+    "Defense": 125,
+    "Special": 115,
+    "Speed": 55,
+    "moves": {
+        "natural": [{
+            "Move": "Horn Attack",
+            "level": 1
+        }, {
+            "Move": "Water Gun",
+            "level": 1
+        }, {
+            "Move": "Withdraw",
+            "level": 1
+        }, {
+            "Move": "Horn Attack",
+            "level": 34
+        }, {
+            "Move": "Leer",
+            "level": 39
+        }, {
+            "Move": "Spike Cannon",
+            "level": 44
+        }, {
+            "Move": "Hydro Pump",
+            "level": 49
+        }],
+        "hm": [{
+            "Move": "Surf",
+            "level": 3
+        }],
+        "tm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Horn Drill",
+            "level": 7
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Bubble Beam",
+            "level": 11
+        }, {
+            "Move": "Water Gun",
+            "level": 12
+        }, {
+            "Move": "Ice Beam",
+            "level": 13
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Onix": {
+    "label": "Rock Snake",
+    "sprite": "water",
+    "info": [
+        "As it grows, the stone portions of its body harden to become similar to a diamond, but colored black."
+    ],
+    "evolvesInto": "Steelix",
+    "evolvesVia": "trade holdingMetal Coat",
+    "number": 095,
+    "height": ["28", "10"],
+    "weight": 463,
+    "types": ["Rock", "Ground"],
+    "HP": 35,
+    "Attack": 45,
+    "Defense": 160,
+    "Special": 30,
+    "Speed": 70,
+    "moves": {
+        "natural": [{
+            "Move": "Screech",
+            "level": 1
+        }, {
+            "Move": "Tackle",
+            "level": 1
+        }, {
+            "Move": "Bind",
+            "level": 15
+        }, {
+            "Move": "Rock Throw",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 25
+        }, {
+            "Move": "Slam",
+            "level": 33
+        }, {
+            "Move": "Harden",
+            "level": 43
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Earthquake",
+            "level": 26
+        }, {
+            "Move": "Fissure",
+            "level": 27
+        }, {
+            "Move": "Dig",
+            "level": 28
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Self-Destruct",
+            "level": 36
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Explosion",
+            "level": 47
+        }, {
+            "Move": "Rock Slide",
+            "level": 48
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Paras": {
+    "label": "Mushroom",
+    "sprite": "water",
+    "info": [
+        "Burrows to suck tree roots. The mushrooms on its back grow by drawing nutrients from the bug host."
+    ],
+    "evolvesInto": "Parasect",
+    "evolvesVia": "Level 24",
+    "number": 046,
+    "height": ["1", "0"],
+    "weight": 11.9,
+    "types": ["Bug", "Grass"],
+    "HP": 35,
+    "Attack": 70,
+    "Defense": 55,
+    "Special": 45,
+    "Speed": 25,
+    "moves": {
+        "natural": [{
+            "Move": "Scratch",
+            "level": 1
+        }, {
+            "Move": "Stun Spore",
+            "level": 13
+        }, {
+            "Move": "Leech Life",
+            "level": 20
+        }, {
+            "Move": "Spore",
+            "level": 27
+        }, {
+            "Move": "Slash",
+            "level": 34
+        }, {
+            "Move": "Growth",
+            "level": 41
+        }],
+        "hm": [{
+            "Move": "Cut",
+            "level": 1
+        }],
+        "tm": [{
+            "Move": "Swords Dance",
+            "level": 3
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mega Drain",
+            "level": 21
+        }, {
+            "Move": "Solar Beam",
+            "level": 22
+        }, {
+            "Move": "Dig",
+            "level": 28
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Parasect": {
+    "label": "Mushroom",
+    "sprite": "water",
+    "info": [
+        "A host-parasite pair in which the parasite mushroom has taken over the host bug. Prefers damp places."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 047,
+    "height": ["3", "3"],
+    "weight": 65,
+    "types": ["Bug", "Grass"],
+    "HP": 60,
+    "Attack": 95,
+    "Defense": 80,
+    "Special": 60,
+    "Speed": 30,
+    "moves": {
+        "natural": [{
+            "Move": "Leech Life",
+            "level": 1
+        }, {
+            "Move": "Scratch",
+            "level": 1
+        }, {
+            "Move": "Stun Spore",
+            "level": 1
+        }, {
+            "Move": "Stun Spore",
+            "level": 13
+        }, {
+            "Move": "Leech Life",
+            "level": 20
+        }, {
+            "Move": "Spore",
+            "level": 30
+        }, {
+            "Move": "Slash",
+            "level": 39
+        }, {
+            "Move": "Growth",
+            "level": 48
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Swords Dance",
+            "level": 3
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mega Drain",
+            "level": 21
+        }, {
+            "Move": "Solar Beam",
+            "level": 22
+        }, {
+            "Move": "Dig",
+            "level": 28
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Persian": {
+    "label": "Classy Cat",
+    "sprite": "water",
+    "info": [
+        "Although its fur has many admirers, it is tough to raise as a pet because of its fickle meanness."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 053,
+    "height": ["3", "3"],
+    "weight": 70.5,
+    "types": ["Normal"],
+    "HP": 65,
+    "Attack": 70,
+    "Defense": 60,
+    "Special": 65,
+    "Speed": 115,
+    "moves": {
+        "natural": [{
+            "Move": "Bite",
+            "level": 1
+        }, {
+            "Move": "Growl",
+            "level": 1
+        }, {
+            "Move": "Scratch",
+            "level": 1
+        }, {
+            "Move": "Screech",
+            "level": 1
+        }, {
+            "Move": "Bite",
+            "level": 12
+        }, {
+            "Move": "Pay Day",
+            "level": 17
+        }, {
+            "Move": "Screech",
+            "level": 24
+        }, {
+            "Move": "Fury Swipes",
+            "level": 37
+        }, {
+            "Move": "Slash",
+            "level": 51
+        }],
+        "hm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Bubble Beam",
+            "level": 11
+        }, {
+            "Move": "Water Gun",
+            "level": 12
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Pay Day",
+            "level": 16
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Thunderbolt",
+            "level": 24
+        }, {
+            "Move": "Thunder",
+            "level": 25
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }],
+        "tm": [{
+            "Move": "Bite",
+            "level": 1
+        }, {
+            "Move": "Growl",
+            "level": 1
+        }, {
+            "Move": "Scratch",
+            "level": 1
+        }, {
+            "Move": "Screech",
+            "level": 1
+        }, {
+            "Move": "Bite",
+            "level": 12
+        }, {
+            "Move": "Pay Day",
+            "level": 17
+        }, {
+            "Move": "Screech",
+            "level": 24
+        }, {
+            "Move": "Fury Swipes",
+            "level": 37
+        }, {
+            "Move": "Slash",
+            "level": 51
+        }]
+    }
+}, "Pidgeot": {
+    "label": "Bird",
+    "sprite": "water",
+    "info": [
+        "When hunting, it skims the surface of water at high speed to pick off unwary prey such as MAGIKARP."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 018,
+    "height": ["4", "11"],
+    "weight": 87.1,
+    "types": ["Normal", "Flying"],
+    "HP": 83,
+    "Attack": 80,
+    "Defense": 75,
+    "Special": 70,
+    "Speed": 101,
+    "moves": {
+        "natural": [{
+            "Move": "Gust",
+            "level": 1
+        }, {
+            "Move": "Quick Attack",
+            "level": 1
+        }, {
+            "Move": "Sand Attack",
+            "level": 1
+        }, {
+            "Move": "Sand Attack",
+            "level": 5
+        }, {
+            "Move": "Quick Attack",
+            "level": 12
+        }, {
+            "Move": "Whirlwind",
+            "level": 21
+        }, {
+            "Move": "Wing Attack",
+            "level": 31
+        }, {
+            "Move": "Agility",
+            "level": 44
+        }, {
+            "Move": "Mirror Move",
+            "level": 54
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Razor Wind",
+            "level": 2
+        }, {
+            "Move": "Whirlwind",
+            "level": 4
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Sky Attack",
+            "level": 43
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Pidgeotto": {
+    "label": "Bird",
+    "sprite": "water",
+    "info": [
+        "Very protective of its sprawling territorial area, this POKÃ©MON will fiercely peck at any intruder."
+    ],
+    "evolvesInto": "Pidgeot",
+    "evolvesVia": "Level 36",
+    "number": 017,
+    "height": ["3", "7"],
+    "weight": 66.1,
+    "types": ["Normal", "Flying"],
+    "HP": 63,
+    "Attack": 60,
+    "Defense": 55,
+    "Special": 50,
+    "Speed": 71,
+    "moves": {
+        "natural": [{
+            "Move": "Gust",
+            "level": 1
+        }, {
+            "Move": "Sand Attack",
+            "level": 1
+        }, {
+            "Move": "Sand Attack",
+            "level": 5
+        }, {
+            "Move": "Quick Attack",
+            "level": 12
+        }, {
+            "Move": "Whirlwind",
+            "level": 21
+        }, {
+            "Move": "Wing Attack",
+            "level": 31
+        }, {
+            "Move": "Agility",
+            "level": 40
+        }, {
+            "Move": "Mirror Move",
+            "level": 49
+        }],
+        "hm": [{
+            "Move": "Fly",
+            "level": 2
+        }],
+        "tm": [{
+            "Move": "Razor Wind",
+            "level": 2
+        }, {
+            "Move": "Whirlwind",
+            "level": 4
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Sky Attack",
+            "level": 43
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Pidgey": {
+    "label": "Tiny Bird",
+    "sprite": "water",
+    "info": [
+        "A common sight in forests and woods. It flaps its wings at ground level to kick up blinding sand."
+    ],
+    "evolvesInto": "Pidgeotto",
+    "evolvesVia": "Level 18",
+    "number": 016,
+    "height": ["1", "0"],
+    "weight": 4,
+    "types": ["Normal", "Flying"],
+    "HP": 40,
+    "Attack": 45,
+    "Defense": 40,
+    "Special": 35,
+    "Speed": 56,
+    "moves": {
+        "natural": [{
+            "Move": "Gust",
+            "level": 1
+        }, {
+            "Move": "Sand Attack",
+            "level": 5
+        }, {
+            "Move": "Quick Attack",
+            "level": 12
+        }, {
+            "Move": "Whirlwind",
+            "level": 19
+        }, {
+            "Move": "Wing Attack",
+            "level": 28
+        }, {
+            "Move": "Agility",
+            "level": 36
+        }, {
+            "Move": "Mirror Move",
+            "level": 44
+        }],
+        "hm": [{
+            "Move": "Fly",
+            "level": 2
+        }],
+        "tm": [{
+            "Move": "Razor Wind",
+            "level": 2
+        }, {
+            "Move": "Whirlwind",
+            "level": 4
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Sky Attack",
+            "level": 43
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Pikachu": {
+    "label": "Mouse",
+    "sprite": "water",
+    "info": [
+        "When several of these POKÃ©MON gather, their electricity could build and cause lightning storms."
+    ],
+    "evolvesInto": "Raichu",
+    "evolvesVia": "use Thunderstone",
+    "number": 025,
+    "height": ["1", "4"],
+    "weight": 13.2,
+    "types": ["Electric"],
+    "HP": 35,
+    "Attack": 55,
+    "Defense": 40,
+    "Special": 50,
+    "Speed": 90,
+    "moves": {
+        "natural": [{
+            "Move": "Growl",
+            "level": 1
+        }, {
+            "Move": "Thunder Shock",
+            "level": 1
+        }, {
+            "Move": "Thunder Wave",
+            "level": 9
+        }, {
+            "Move": "Quick Attack",
+            "level": 16
+        }, {
+            "Move": "Swift",
+            "level": 26
+        }, {
+            "Move": "Agility",
+            "level": 33
+        }, {
+            "Move": "Thunder",
+            "level": 43
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Mega Punch",
+            "level": 1
+        }, {
+            "Move": "Mega Kick",
+            "level": 5
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Pay Day",
+            "level": 16
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Thunderbolt",
+            "level": 24
+        }, {
+            "Move": "Thunder",
+            "level": 25
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Thunder Wave",
+            "level": 45
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Pinsir": {
+    "label": "Stag Beetle",
+    "sprite": "water",
+    "info": [
+        "If it fails to crush the victim in its pincers, it will swing it around and toss it hard."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 127,
+    "height": ["4", "11"],
+    "weight": 121.3,
+    "types": ["Bug"],
+    "HP": 65,
+    "Attack": 125,
+    "Defense": 100,
+    "Special": 55,
+    "Speed": 85,
+    "moves": {
+        "natural": [{
+            "Move": "Vice Grip",
+            "level": 1
+        }, {
+            "Move": "Seismic Toss",
+            "level": 25
+        }, {
+            "Move": "Guillotine",
+            "level": 30
+        }, {
+            "Move": "Focus Energy",
+            "level": 36
+        }, {
+            "Move": "Harden",
+            "level": 43
+        }, {
+            "Move": "Slash",
+            "level": 49
+        }, {
+            "Move": "Swords Dance",
+            "level": 54
+        }],
+        "hm": [{
+            "Move": "Cut",
+            "level": 1
+        }, {
+            "Move": "Strength",
+            "level": 4
+        }],
+        "tm": [{
+            "Move": "Swords Dance",
+            "level": 3
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Poliwag": {
+    "label": "Tadpole",
+    "sprite": "water",
+    "info": [
+        "Its newly grown legs prevent it from running. It appears to prefer swimming than trying to stand."
+    ],
+    "evolvesInto": "Poliwhirl",
+    "evolvesVia": "Level 25",
+    "number": 060,
+    "height": ["2", "0"],
+    "weight": 27.3,
+    "types": ["Water"],
+    "HP": 40,
+    "Attack": 50,
+    "Defense": 40,
+    "Special": 40,
+    "Speed": 90,
+    "moves": {
+        "natural": [{
+            "Move": "Bubble",
+            "level": 1
+        }, {
+            "Move": "Hypnosis",
+            "level": 16
+        }, {
+            "Move": "Water Gun",
+            "level": 19
+        }, {
+            "Move": "Double Slap",
+            "level": 25
+        }, {
+            "Move": "Body Slam",
+            "level": 31
+        }, {
+            "Move": "Amnesia",
+            "level": 38
+        }, {
+            "Move": "Hydro Pump",
+            "level": 45
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Bubble Beam",
+            "level": 11
+        }, {
+            "Move": "Water Gun",
+            "level": 12
+        }, {
+            "Move": "Ice Beam",
+            "level": 13
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Psychic",
+            "level": 29
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Psywave",
+            "level": 46
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Poliwhirl": {
+    "label": "Tadpole",
+    "sprite": "water",
+    "info": [
+        "Capable of living in or out of water. When out of water, it sweats to keep its body slimy."
+    ],
+    "evolvesInto": "Poliwrath",
+    "evolvesVia": "↗",
+    "number": 061,
+    "height": ["3", "3"],
+    "weight": 44.1,
+    "types": ["Water"],
+    "HP": 65,
+    "Attack": 65,
+    "Defense": 65,
+    "Special": 50,
+    "Speed": 90,
+    "moves": {
+        "natural": [{
+            "Move": "Bubble",
+            "level": 1
+        }, {
+            "Move": "Hypnosis",
+            "level": 1
+        }, {
+            "Move": "Water Gun",
+            "level": 1
+        }, {
+            "Move": "Hypnosis",
+            "level": 16
+        }, {
+            "Move": "Water Gun",
+            "level": 19
+        }, {
+            "Move": "Double Slap",
+            "level": 26
+        }, {
+            "Move": "Body Slam",
+            "level": 33
+        }, {
+            "Move": "Amnesia",
+            "level": 41
+        }, {
+            "Move": "Hydro Pump",
+            "level": 49
+        }],
+        "hm": [{
+            "Move": "Surf",
+            "level": 3
+        }, {
+            "Move": "Strength",
+            "level": 4
+        }],
+        "tm": [{
+            "Move": "Mega Punch",
+            "level": 1
+        }, {
+            "Move": "Mega Kick",
+            "level": 5
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Bubble Beam",
+            "level": 11
+        }, {
+            "Move": "Water Gun",
+            "level": 12
+        }, {
+            "Move": "Ice Beam",
+            "level": 13
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Counter",
+            "level": 18
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Earthquake",
+            "level": 26
+        }, {
+            "Move": "Fissure",
+            "level": 27
+        }, {
+            "Move": "Psychic",
+            "level": 29
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Metronome",
+            "level": 35
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Psywave",
+            "level": 46
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Poliwrath": {
+    "label": "Tadpole",
+    "sprite": "water",
+    "info": [
+        "An adept swimmer at both the front crawl and breast stroke. Easily overtakes the best human swimmers."
+    ],
+    "evolvesInto": "Politoed",
+    "evolvesVia": "trade holdingKing's Rock",
+    "number": 062,
+    "height": ["4", "3"],
+    "weight": 119,
+    "types": ["Water", "Fighting"],
+    "HP": 90,
+    "Attack": 95,
+    "Defense": 95,
+    "Special": 70,
+    "Speed": 70,
+    "moves": {
+        "natural": [{
+            "Move": "Body Slam",
+            "level": 1
+        }, {
+            "Move": "Double Slap",
+            "level": 1
+        }, {
+            "Move": "Hypnosis",
+            "level": 1
+        }, {
+            "Move": "Water Gun",
+            "level": 1
+        }, {
+            "Move": "Hypnosis",
+            "level": 16
+        }, {
+            "Move": "Water Gun",
+            "level": 19
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Surf",
+            "level": 3
+        }, {
+            "Move": "Strength",
+            "level": 4
+        }]
+    }
+}, "Ponyta": {
+    "label": "Fire Horse",
+    "sprite": "water",
+    "info": [
+        "Its hooves are 10 times harder than diamonds. It can trample anything completely flat in little time."
+    ],
+    "evolvesInto": "Rapidash",
+    "evolvesVia": "Level 40",
+    "number": 077,
+    "height": ["3", "3"],
+    "weight": 66.1,
+    "types": ["Fire"],
+    "HP": 50,
+    "Attack": 85,
+    "Defense": 55,
+    "Special": 65,
+    "Speed": 90,
+    "moves": {
+        "natural": [{
+            "Move": "Ember",
+            "level": 1
+        }, {
+            "Move": "Tail Whip",
+            "level": 30
+        }, {
+            "Move": "Stomp",
+            "level": 32
+        }, {
+            "Move": "Growl",
+            "level": 35
+        }, {
+            "Move": "Fire Spin",
+            "level": 39
+        }, {
+            "Move": "Take Down",
+            "level": 43
+        }, {
+            "Move": "Agility",
+            "level": 48
+        }],
+        "hm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Horn Drill",
+            "level": 7
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Fire Blast",
+            "level": 38
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }],
+        "tm": [{
+            "Move": "Ember",
+            "level": 1
+        }, {
+            "Move": "Tail Whip",
+            "level": 30
+        }, {
+            "Move": "Stomp",
+            "level": 32
+        }, {
+            "Move": "Growl",
+            "level": 35
+        }, {
+            "Move": "Fire Spin",
+            "level": 39
+        }, {
+            "Move": "Take Down",
+            "level": 43
+        }, {
+            "Move": "Agility",
+            "level": 48
+        }]
+    }
+}, "Porygon": {
+    "label": "Virtual",
+    "sprite": "water",
+    "info": [
+        "A POKÃ©MON that consists entirely of programming code. Capable of moving freely in cyberspace."
+    ],
+    "evolvesInto": "Porygon2",
+    "evolvesVia": "trade holdingUp-Grade",
+    "number": 137,
+    "height": ["2", "7"],
+    "weight": 80.5,
+    "types": ["Normal"],
+    "HP": 65,
+    "Attack": 60,
+    "Defense": 70,
+    "Special": 85,
+    "Speed": 40,
+    "moves": {
+        "natural": [{
+            "Move": "Conversion",
+            "level": 1
+        }, {
+            "Move": "Sharpen",
+            "level": 1
+        }, {
+            "Move": "Tackle",
+            "level": 1
+        }, {
+            "Move": "Psybeam",
+            "level": 23
+        }, {
+            "Move": "Recover",
+            "level": 28
+        }, {
+            "Move": "Agility",
+            "level": 35
+        }, {
+            "Move": "Tri Attack",
+            "level": 42
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Ice Beam",
+            "level": 13
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Thunderbolt",
+            "level": 24
+        }, {
+            "Move": "Thunder",
+            "level": 25
+        }, {
+            "Move": "Psychic",
+            "level": 29
+        }, {
+            "Move": "Teleport",
+            "level": 30
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Thunder Wave",
+            "level": 45
+        }, {
+            "Move": "Psywave",
+            "level": 46
+        }, {
+            "Move": "Tri Attack",
+            "level": 49
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Primeape": {
+    "label": "Pig Monkey",
+    "sprite": "water",
+    "info": [
+        "Always furious and tenacious to boot. It will not abandon chasing its quarry until it is caught."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 057,
+    "height": ["3", "3"],
+    "weight": 70.5,
+    "types": ["Fighting"],
+    "HP": 65,
+    "Attack": 105,
+    "Defense": 60,
+    "Special": 60,
+    "Speed": 95,
+    "moves": {
+        "natural": [{
+            "Move": "Fury Swipes",
+            "level": 1
+        }, {
+            "Move": "Karate Chop",
+            "level": 1
+        }, {
+            "Move": "Leer",
+            "level": 1
+        }, {
+            "Move": "Scratch",
+            "level": 1
+        }, {
+            "Move": "Karate Chop",
+            "level": 15
+        }, {
+            "Move": "Fury Swipes",
+            "level": 21
+        }, {
+            "Move": "Focus Energy",
+            "level": 27
+        }, {
+            "Move": "Seismic Toss",
+            "level": 37
+        }, {
+            "Move": "Thrash",
+            "level": 46
+        }],
+        "hm": [{
+            "Move": "Strength",
+            "level": 4
+        }],
+        "tm": [{
+            "Move": "Mega Punch",
+            "level": 1
+        }, {
+            "Move": "Mega Kick",
+            "level": 5
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Pay Day",
+            "level": 16
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Counter",
+            "level": 18
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Thunderbolt",
+            "level": 24
+        }, {
+            "Move": "Thunder",
+            "level": 25
+        }, {
+            "Move": "Dig",
+            "level": 28
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Metronome",
+            "level": 35
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Rock Slide",
+            "level": 48
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Psyduck": {
+    "label": "Duck",
+    "sprite": "water",
+    "info": [
+        "While lulling its enemies with its vacant look, this wily POKÃ©MON will use psychokinetic powers."
+    ],
+    "evolvesInto": "Golduck",
+    "evolvesVia": "Level 33",
+    "number": 054,
+    "height": ["2", "7"],
+    "weight": 43.2,
+    "types": ["Water"],
+    "HP": 50,
+    "Attack": 52,
+    "Defense": 48,
+    "Special": 65,
+    "Speed": 55,
+    "moves": {
+        "natural": [{
+            "Move": "Scratch",
+            "level": 1
+        }, {
+            "Move": "Tail Whip",
+            "level": 28
+        }, {
+            "Move": "Disable",
+            "level": 31
+        }, {
+            "Move": "Confusion",
+            "level": 36
+        }, {
+            "Move": "Fury Swipes",
+            "level": 43
+        }, {
+            "Move": "Hydro Pump",
+            "level": 52
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Mega Punch",
+            "level": 1
+        }, {
+            "Move": "Mega Kick",
+            "level": 5
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Bubble Beam",
+            "level": 11
+        }, {
+            "Move": "Water Gun",
+            "level": 12
+        }, {
+            "Move": "Ice Beam",
+            "level": 13
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Pay Day",
+            "level": 16
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Counter",
+            "level": 18
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Dig",
+            "level": 28
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Raichu": {
+    "label": "Mouse",
+    "sprite": "water",
+    "info": [
+        "Its long tail serves as a ground to protect itself from its own high voltage power."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 026,
+    "height": ["2", "7"],
+    "weight": 66.1,
+    "types": ["Electric"],
+    "HP": 60,
+    "Attack": 90,
+    "Defense": 55,
+    "Special": 90,
+    "Speed": 110,
+    "moves": {
+        "natural": [{
+            "Move": "Growl",
+            "level": 1
+        }, {
+            "Move": "Thunder Shock",
+            "level": 1
+        }, {
+            "Move": "Thunder Wave",
+            "level": 1
+        }],
+        "hm": [{
+            "Move": "Flash",
+            "level": 5
+        }],
+        "tm": [{
+            "Move": "Flash",
+            "level": 5
+        }]
+    }
+}, "Rapidash": {
+    "label": "Fire Horse",
+    "sprite": "water",
+    "info": [
+        "Very competitive, this POKÃ©MON will chase anything that moves fast in the hopes of racing it."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 078,
+    "height": ["5", "7"],
+    "weight": 209.4,
+    "types": ["Fire"],
+    "HP": 65,
+    "Attack": 100,
+    "Defense": 70,
+    "Special": 80,
+    "Speed": 105,
+    "moves": {
+        "natural": [{
+            "Move": "Ember",
+            "level": 1
+        }, {
+            "Move": "Growl",
+            "level": 1
+        }, {
+            "Move": "Stomp",
+            "level": 1
+        }, {
+            "Move": "Tail Whip",
+            "level": 1
+        }, {
+            "Move": "Tail Whip",
+            "level": 30
+        }, {
+            "Move": "Stomp",
+            "level": 32
+        }, {
+            "Move": "Growl",
+            "level": 35
+        }, {
+            "Move": "Fire Spin",
+            "level": 39
+        }, {
+            "Move": "Take Down",
+            "level": 47
+        }, {
+            "Move": "Agility",
+            "level": 55
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Ember",
+            "level": 1
+        }, {
+            "Move": "Growl",
+            "level": 1
+        }, {
+            "Move": "Stomp",
+            "level": 1
+        }, {
+            "Move": "Tail Whip",
+            "level": 1
+        }, {
+            "Move": "Tail Whip",
+            "level": 30
+        }, {
+            "Move": "Stomp",
+            "level": 32
+        }, {
+            "Move": "Growl",
+            "level": 35
+        }, {
+            "Move": "Fire Spin",
+            "level": 39
+        }, {
+            "Move": "Take Down",
+            "level": 47
+        }, {
+            "Move": "Agility",
+            "level": 55
+        }]
+    }
+}, "Raticate": {
+    "label": "Mouse",
+    "sprite": "water",
+    "info": [
+        "It uses its whiskers to maintain its balance. It apparently slows down if they are cut off."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 020,
+    "height": ["2", "4"],
+    "weight": 40.8,
+    "types": ["Normal"],
+    "HP": 55,
+    "Attack": 81,
+    "Defense": 60,
+    "Special": 50,
+    "Speed": 97,
+    "moves": {
+        "natural": [{
+            "Move": "Quick Attack",
+            "level": 1
+        }, {
+            "Move": "Tackle",
+            "level": 1
+        }, {
+            "Move": "Tail Whip",
+            "level": 1
+        }, {
+            "Move": "Quick Attack",
+            "level": 7
+        }, {
+            "Move": "Hyper Fang",
+            "level": 14
+        }, {
+            "Move": "Focus Energy",
+            "level": 27
+        }, {
+            "Move": "Super Fang",
+            "level": 41
+        }],
+        "hm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Bubble Beam",
+            "level": 11
+        }, {
+            "Move": "Water Gun",
+            "level": 12
+        }, {
+            "Move": "Ice Beam",
+            "level": 13
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Thunderbolt",
+            "level": 24
+        }, {
+            "Move": "Thunder",
+            "level": 25
+        }, {
+            "Move": "Dig",
+            "level": 28
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }],
+        "tm": [{
+            "Move": "Quick Attack",
+            "level": 1
+        }, {
+            "Move": "Tackle",
+            "level": 1
+        }, {
+            "Move": "Tail Whip",
+            "level": 1
+        }, {
+            "Move": "Quick Attack",
+            "level": 7
+        }, {
+            "Move": "Hyper Fang",
+            "level": 14
+        }, {
+            "Move": "Focus Energy",
+            "level": 27
+        }, {
+            "Move": "Super Fang",
+            "level": 41
+        }]
+    }
+}, "Rattata": {
+    "label": "Mouse",
+    "sprite": "water",
+    "info": [
+        "Bites anything when it attacks. Small and very quick, it is a common sight in many places."
+    ],
+    "evolvesInto": "Raticate",
+    "evolvesVia": "Level 20",
+    "number": 019,
+    "height": ["1", "0"],
+    "weight": 7.7,
+    "types": ["Normal"],
+    "HP": 30,
+    "Attack": 56,
+    "Defense": 35,
+    "Special": 25,
+    "Speed": 72,
+    "moves": {
+        "natural": [{
+            "Move": "Tackle",
+            "level": 1
+        }, {
+            "Move": "Tail Whip",
+            "level": 1
+        }, {
+            "Move": "Quick Attack",
+            "level": 7
+        }, {
+            "Move": "Hyper Fang",
+            "level": 14
+        }, {
+            "Move": "Focus Energy",
+            "level": 23
+        }, {
+            "Move": "Super Fang",
+            "level": 34
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Tackle",
+            "level": 1
+        }, {
+            "Move": "Tail Whip",
+            "level": 1
+        }, {
+            "Move": "Quick Attack",
+            "level": 7
+        }, {
+            "Move": "Hyper Fang",
+            "level": 14
+        }, {
+            "Move": "Focus Energy",
+            "level": 23
+        }, {
+            "Move": "Super Fang",
+            "level": 34
+        }]
+    }
+}, "Rhydon": {
+    "label": "Drill",
+    "sprite": "water",
+    "info": [
+        "Protected by an armor-like hide, it is capable of living in molten lava of 3,600 degrees."
+    ],
+    "evolvesInto": "Rhyperior",
+    "evolvesVia": "trade holdingProtector",
+    "number": 112,
+    "height": ["6", "3"],
+    "weight": 264.6,
+    "types": ["Ground", "Rock"],
+    "HP": 105,
+    "Attack": 130,
+    "Defense": 120,
+    "Special": 45,
+    "Speed": 40,
+    "moves": {
+        "natural": [{
+            "Move": "Fury Attack",
+            "level": 1
+        }, {
+            "Move": "Horn Attack",
+            "level": 1
+        }, {
+            "Move": "Stomp",
+            "level": 1
+        }, {
+            "Move": "Tail Whip",
+            "level": 1
+        }, {
+            "Move": "Stomp",
+            "level": 30
+        }, {
+            "Move": "Tail Whip",
+            "level": 35
+        }, {
+            "Move": "Fury Attack",
+            "level": 40
+        }, {
+            "Move": "Horn Drill",
+            "level": 48
+        }, {
+            "Move": "Leer",
+            "level": 55
+        }, {
+            "Move": "Take Down",
+            "level": 64
+        }],
+        "hm": [{
+            "Move": "Surf",
+            "level": 3
+        }, {
+            "Move": "Strength",
+            "level": 4
+        }],
+        "tm": [{
+            "Move": "Mega Punch",
+            "level": 1
+        }, {
+            "Move": "Mega Kick",
+            "level": 5
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Horn Drill",
+            "level": 7
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Bubble Beam",
+            "level": 11
+        }, {
+            "Move": "Water Gun",
+            "level": 12
+        }, {
+            "Move": "Ice Beam",
+            "level": 13
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Pay Day",
+            "level": 16
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Counter",
+            "level": 18
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Thunderbolt",
+            "level": 24
+        }, {
+            "Move": "Thunder",
+            "level": 25
+        }, {
+            "Move": "Earthquake",
+            "level": 26
+        }, {
+            "Move": "Fissure",
+            "level": 27
+        }, {
+            "Move": "Dig",
+            "level": 28
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Fire Blast",
+            "level": 38
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Rock Slide",
+            "level": 48
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Rhyhorn": {
+    "label": "Spikes",
+    "sprite": "water",
+    "info": [
+        "Its massive bones are 1000 times harder than human bones. It can easily knock a trailer flying."
+    ],
+    "evolvesInto": "Rhydon",
+    "evolvesVia": "Level 42",
+    "number": 111,
+    "height": ["3", "3"],
+    "weight": 253.5,
+    "types": ["Ground", "Rock"],
+    "HP": 80,
+    "Attack": 85,
+    "Defense": 95,
+    "Special": 30,
+    "Speed": 25,
+    "moves": {
+        "natural": [{
+            "Move": "Horn Attack",
+            "level": 1
+        }, {
+            "Move": "Stomp",
+            "level": 30
+        }, {
+            "Move": "Tail Whip",
+            "level": 35
+        }, {
+            "Move": "Fury Attack",
+            "level": 40
+        }, {
+            "Move": "Horn Drill",
+            "level": 45
+        }, {
+            "Move": "Leer",
+            "level": 50
+        }, {
+            "Move": "Take Down",
+            "level": 55
+        }],
+        "hm": [{
+            "Move": "Strength",
+            "level": 4
+        }],
+        "tm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Horn Drill",
+            "level": 7
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Thunderbolt",
+            "level": 24
+        }, {
+            "Move": "Thunder",
+            "level": 25
+        }, {
+            "Move": "Earthquake",
+            "level": 26
+        }, {
+            "Move": "Fissure",
+            "level": 27
+        }, {
+            "Move": "Dig",
+            "level": 28
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Fire Blast",
+            "level": 38
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Rock Slide",
+            "level": 48
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Sandshrew": {
+    "label": "Mouse",
+    "sprite": "water",
+    "info": [
+        "Burrows deep underground in arid locations far from water. It only emerges to hunt for food."
+    ],
+    "evolvesInto": "Sandslash",
+    "evolvesVia": "Level 22",
+    "number": 027,
+    "height": ["2", "0"],
+    "weight": 26.5,
+    "types": ["Ground"],
+    "HP": 50,
+    "Attack": 75,
+    "Defense": 85,
+    "Special": 20,
+    "Speed": 40,
+    "moves": {
+        "natural": [{
+            "Move": "Scratch",
+            "level": 1
+        }, {
+            "Move": "Sand Attack",
+            "level": 10
+        }, {
+            "Move": "Slash",
+            "level": 17
+        }, {
+            "Move": "Poison Sting",
+            "level": 24
+        }, {
+            "Move": "Swift",
+            "level": 31
+        }, {
+            "Move": "Fury Swipes",
+            "level": 38
+        }],
+        "hm": [{
+            "Move": "Cut",
+            "level": 1
+        }, {
+            "Move": "Strength",
+            "level": 4
+        }],
+        "tm": [{
+            "Move": "Swords Dance",
+            "level": 3
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Earthquake",
+            "level": 26
+        }, {
+            "Move": "Fissure",
+            "level": 27
+        }, {
+            "Move": "Dig",
+            "level": 28
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Rock Slide",
+            "level": 48
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Sandslash": {
+    "label": "Mouse",
+    "sprite": "water",
+    "info": [
+        "Curls up into a spiny ball when threatened. It can roll while curled up to attack or escape."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 028,
+    "height": ["3", "3"],
+    "weight": 65,
+    "types": ["Ground"],
+    "HP": 75,
+    "Attack": 100,
+    "Defense": 110,
+    "Special": 45,
+    "Speed": 65,
+    "moves": {
+        "natural": [{
+            "Move": "Sand Attack",
+            "level": 1
+        }, {
+            "Move": "Scratch",
+            "level": 1
+        }, {
+            "Move": "Sand Attack",
+            "level": 10
+        }, {
+            "Move": "Slash",
+            "level": 17
+        }, {
+            "Move": "Poison Sting",
+            "level": 27
+        }, {
+            "Move": "Swift",
+            "level": 36
+        }, {
+            "Move": "Fury Swipes",
+            "level": 47
+        }],
+        "hm": [{
+            "Move": "Cut",
+            "level": 1
+        }, {
+            "Move": "Strength",
+            "level": 4
+        }],
+        "tm": [{
+            "Move": "Swords Dance",
+            "level": 3
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Earthquake",
+            "level": 26
+        }, {
+            "Move": "Fissure",
+            "level": 27
+        }, {
+            "Move": "Dig",
+            "level": 28
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Rock Slide",
+            "level": 48
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Scyther": {
+    "label": "Mantis",
+    "sprite": "water",
+    "info": [
+        "With ninja-like agility and speed, it can create the illusion that there is more than one."
+    ],
+    "evolvesInto": "Scizor",
+    "evolvesVia": "trade holdingMetal Coat",
+    "number": 123,
+    "height": ["4", "11"],
+    "weight": 123.5,
+    "types": ["Bug", "Flying"],
+    "HP": 70,
+    "Attack": 110,
+    "Defense": 80,
+    "Special": 55,
+    "Speed": 105,
+    "moves": {
+        "natural": [{
+            "Move": "Quick Attack",
+            "level": 1
+        }, {
+            "Move": "Leer",
+            "level": 17
+        }, {
+            "Move": "Focus Energy",
+            "level": 20
+        }, {
+            "Move": "Double Team",
+            "level": 24
+        }, {
+            "Move": "Slash",
+            "level": 29
+        }, {
+            "Move": "Swords Dance",
+            "level": 35
+        }, {
+            "Move": "Agility",
+            "level": 42
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Swords Dance",
+            "level": 3
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Seadra": {
+    "label": "Dragon",
+    "sprite": "water",
+    "info": [
+        "Capable of swimming backwards by rapidly flapping its wing-like pectoral fins and stout tail."
+    ],
+    "evolvesInto": "Kingdra",
+    "evolvesVia": "trade holdingDragon Scale",
+    "number": 117,
+    "height": ["3", "11"],
+    "weight": 55.1,
+    "types": ["Water"],
+    "HP": 55,
+    "Attack": 65,
+    "Defense": 95,
+    "Special": 95,
+    "Speed": 85,
+    "moves": {
+        "natural": [{
+            "Move": "Bubble",
+            "level": 1
+        }, {
+            "Move": "Smokescreen",
+            "level": 1
+        }, {
+            "Move": "Smokescreen",
+            "level": 19
+        }, {
+            "Move": "Leer",
+            "level": 24
+        }, {
+            "Move": "Water Gun",
+            "level": 30
+        }, {
+            "Move": "Agility",
+            "level": 41
+        }, {
+            "Move": "Hydro Pump",
+            "level": 52
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Bubble Beam",
+            "level": 11
+        }, {
+            "Move": "Water Gun",
+            "level": 12
+        }, {
+            "Move": "Ice Beam",
+            "level": 13
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Seaking": {
+    "label": "Goldfish",
+    "sprite": "water",
+    "info": [
+        "In the autumn spawning season, they can be seen swimming powerfully up rivers and creeks."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 119,
+    "height": ["4", "3"],
+    "weight": 86,
+    "types": ["Water"],
+    "HP": 80,
+    "Attack": 92,
+    "Defense": 65,
+    "Special": 65,
+    "Speed": 68,
+    "moves": {
+        "natural": [{
+            "Move": "Peck",
+            "level": 1
+        }, {
+            "Move": "Supersonic",
+            "level": 1
+        }, {
+            "Move": "Tail Whip",
+            "level": 1
+        }, {
+            "Move": "Supersonic",
+            "level": 19
+        }, {
+            "Move": "Horn Attack",
+            "level": 24
+        }, {
+            "Move": "Fury Attack",
+            "level": 30
+        }, {
+            "Move": "Waterfall",
+            "level": 39
+        }, {
+            "Move": "Horn Drill",
+            "level": 48
+        }, {
+            "Move": "Agility",
+            "level": 54
+        }],
+        "hm": [{
+            "Move": "Surf",
+            "level": 3
+        }],
+        "tm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Horn Drill",
+            "level": 7
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Bubble Beam",
+            "level": 11
+        }, {
+            "Move": "Water Gun",
+            "level": 12
+        }, {
+            "Move": "Ice Beam",
+            "level": 13
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Seel": {
+    "label": "Sea Lion",
+    "sprite": "water",
+    "info": [
+        "The protruding horn on its head is very hard. It is used for bashing through thick ice."
+    ],
+    "evolvesInto": "Dewgong",
+    "evolvesVia": "Level 34",
+    "number": 086,
+    "height": ["3", "7"],
+    "weight": 198.4,
+    "types": ["Water"],
+    "HP": 65,
+    "Attack": 45,
+    "Defense": 55,
+    "Special": 45,
+    "Speed": 45,
+    "moves": {
+        "natural": [{
+            "Move": "Headbutt",
+            "level": 1
+        }, {
+            "Move": "Growl",
+            "level": 30
+        }, {
+            "Move": "Aurora Beam",
+            "level": 35
+        }, {
+            "Move": "Rest",
+            "level": 40
+        }, {
+            "Move": "Take Down",
+            "level": 45
+        }, {
+            "Move": "Ice Beam",
+            "level": 50
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Horn Drill",
+            "level": 7
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Bubble Beam",
+            "level": 11
+        }, {
+            "Move": "Water Gun",
+            "level": 12
+        }, {
+            "Move": "Ice Beam",
+            "level": 13
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Pay Day",
+            "level": 16
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Shellder": {
+    "label": "Bivalve",
+    "sprite": "water",
+    "info": [
+        "Its hard shell repels any kind of attack. It is vulnerable only when its shell is open."
+    ],
+    "evolvesInto": "Cloyster",
+    "evolvesVia": "use Water Stone",
+    "number": 090,
+    "height": ["1", "0"],
+    "weight": 8.8,
+    "types": ["Water"],
+    "HP": 30,
+    "Attack": 65,
+    "Defense": 100,
+    "Special": 45,
+    "Speed": 40,
+    "moves": {
+        "natural": [{
+            "Move": "Tackle",
+            "level": 1
+        }, {
+            "Move": "Withdraw",
+            "level": 1
+        }, {
+            "Move": "Supersonic",
+            "level": 18
+        }, {
+            "Move": "Clamp",
+            "level": 23
+        }, {
+            "Move": "Aurora Beam",
+            "level": 30
+        }, {
+            "Move": "Leer",
+            "level": 39
+        }, {
+            "Move": "Ice Beam",
+            "level": 50
+        }],
+        "hm": [{
+            "Move": "Surf",
+            "level": 3
+        }],
+        "tm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Bubble Beam",
+            "level": 11
+        }, {
+            "Move": "Water Gun",
+            "level": 12
+        }, {
+            "Move": "Ice Beam",
+            "level": 13
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Teleport",
+            "level": 30
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Self-Destruct",
+            "level": 36
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Explosion",
+            "level": 47
+        }, {
+            "Move": "Tri Attack",
+            "level": 49
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Slowbro": {
+    "label": "Hermit Crab",
+    "sprite": "water",
+    "info": [
+        "The SHELLDER that is latched onto SLOWPOKE's tail is said to feed on the host's left over scraps."
+    ],
+    "evolvesInto": "Slowking",
+    "evolvesVia": "trade holdingKing's Rock",
+    "number": 080,
+    "height": ["5", "3"],
+    "weight": 173.1,
+    "types": ["Water", "Psychic"],
+    "HP": 95,
+    "Attack": 75,
+    "Defense": 110,
+    "Special": 100,
+    "Speed": 30,
+    "moves": {
+        "natural": [{
+            "Move": "Confusion",
+            "level": 1
+        }, {
+            "Move": "Disable",
+            "level": 1
+        }, {
+            "Move": "Headbutt",
+            "level": 1
+        }, {
+            "Move": "Disable",
+            "level": 18
+        }, {
+            "Move": "Headbutt",
+            "level": 22
+        }, {
+            "Move": "Growl",
+            "level": 27
+        }, {
+            "Move": "Water Gun",
+            "level": 33
+        }, {
+            "Move": "Withdraw",
+            "level": 37
+        }, {
+            "Move": "Amnesia",
+            "level": 44
+        }, {
+            "Move": "Psychic",
+            "level": 55
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Mega Punch",
+            "level": 1
+        }, {
+            "Move": "Mega Kick",
+            "level": 5
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Bubble Beam",
+            "level": 11
+        }, {
+            "Move": "Water Gun",
+            "level": 12
+        }, {
+            "Move": "Ice Beam",
+            "level": 13
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Pay Day",
+            "level": 16
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Counter",
+            "level": 18
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Earthquake",
+            "level": 26
+        }, {
+            "Move": "Fissure",
+            "level": 27
+        }, {
+            "Move": "Dig",
+            "level": 28
+        }, {
+            "Move": "Psychic",
+            "level": 29
+        }, {
+            "Move": "Teleport",
+            "level": 30
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Fire Blast",
+            "level": 38
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Thunder Wave",
+            "level": 45
+        }, {
+            "Move": "Psywave",
+            "level": 46
+        }, {
+            "Move": "Tri Attack",
+            "level": 49
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Slowpoke": {
+    "label": "Dopey",
+    "sprite": "water",
+    "info": [
+        "Incredibly slow and dopey. It takes 5 seconds for it to feel pain when under attack."
+    ],
+    "evolvesInto": "Slowbro",
+    "evolvesVia": "↗",
+    "number": 079,
+    "height": ["3", "11"],
+    "weight": 79.4,
+    "types": ["Water", "Psychic"],
+    "HP": 90,
+    "Attack": 65,
+    "Defense": 65,
+    "Special": 40,
+    "Speed": 15,
+    "moves": {
+        "natural": [{
+            "Move": "Confusion",
+            "level": 1
+        }, {
+            "Move": "Disable",
+            "level": 18
+        }, {
+            "Move": "Headbutt",
+            "level": 22
+        }, {
+            "Move": "Growl",
+            "level": 27
+        }, {
+            "Move": "Water Gun",
+            "level": 33
+        }, {
+            "Move": "Amnesia",
+            "level": 40
+        }, {
+            "Move": "Psychic",
+            "level": 48
+        }],
+        "hm": [{
+            "Move": "Surf",
+            "level": 3
+        }, {
+            "Move": "Strength",
+            "level": 4
+        }, {
+            "Move": "Flash",
+            "level": 5
+        }],
+        "tm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Bubble Beam",
+            "level": 11
+        }, {
+            "Move": "Water Gun",
+            "level": 12
+        }, {
+            "Move": "Ice Beam",
+            "level": 13
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Pay Day",
+            "level": 16
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Earthquake",
+            "level": 26
+        }, {
+            "Move": "Fissure",
+            "level": 27
+        }, {
+            "Move": "Dig",
+            "level": 28
+        }, {
+            "Move": "Psychic",
+            "level": 29
+        }, {
+            "Move": "Teleport",
+            "level": 30
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Fire Blast",
+            "level": 38
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Thunder Wave",
+            "level": 45
+        }, {
+            "Move": "Psywave",
+            "level": 46
+        }, {
+            "Move": "Tri Attack",
+            "level": 49
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Snorlax": {
+    "label": "Sleeping",
+    "sprite": "water",
+    "info": [
+        "Very lazy. Just eats and sleeps. As its rotund bulk builds, it becomes steadily more slothful."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 143,
+    "height": ["6", "11"],
+    "weight": 1014.1,
+    "types": ["Normal"],
+    "HP": 160,
+    "Attack": 110,
+    "Defense": 65,
+    "Special": 65,
+    "Speed": 30,
+    "moves": {
+        "natural": [{
+            "Move": "Amnesia",
+            "level": 1
+        }, {
+            "Move": "Headbutt",
+            "level": 1
+        }, {
+            "Move": "Rest",
+            "level": 1
+        }, {
+            "Move": "Body Slam",
+            "level": 35
+        }, {
+            "Move": "Harden",
+            "level": 41
+        }, {
+            "Move": "Double-Edge",
+            "level": 48
+        }, {
+            "Move": "Hyper Beam",
+            "level": 56
+        }],
+        "hm": [{
+            "Move": "Surf",
+            "level": 3
+        }, {
+            "Move": "Strength",
+            "level": 4
+        }],
+        "tm": [{
+            "Move": "Mega Punch",
+            "level": 1
+        }, {
+            "Move": "Mega Kick",
+            "level": 5
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Bubble Beam",
+            "level": 11
+        }, {
+            "Move": "Water Gun",
+            "level": 12
+        }, {
+            "Move": "Ice Beam",
+            "level": 13
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Pay Day",
+            "level": 16
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Counter",
+            "level": 18
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Solar Beam",
+            "level": 22
+        }, {
+            "Move": "Thunderbolt",
+            "level": 24
+        }, {
+            "Move": "Thunder",
+            "level": 25
+        }, {
+            "Move": "Earthquake",
+            "level": 26
+        }, {
+            "Move": "Fissure",
+            "level": 27
+        }, {
+            "Move": "Psychic",
+            "level": 29
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Metronome",
+            "level": 35
+        }, {
+            "Move": "Self-Destruct",
+            "level": 36
+        }, {
+            "Move": "Fire Blast",
+            "level": 38
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Psywave",
+            "level": 46
+        }, {
+            "Move": "Rock Slide",
+            "level": 48
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Spearow": {
+    "label": "Tiny Bird",
+    "sprite": "water",
+    "info": [
+        "Eats bugs in grassy areas. It has to flap its short wings at high speed to stay airborne."
+    ],
+    "evolvesInto": "Fearow",
+    "evolvesVia": "Level 20",
+    "number": 021,
+    "height": ["1", "0"],
+    "weight": 4.4,
+    "types": ["Normal", "Flying"],
+    "HP": 40,
+    "Attack": 60,
+    "Defense": 30,
+    "Special": 31,
+    "Speed": 70,
+    "moves": {
+        "natural": [{
+            "Move": "Growl",
+            "level": 1
+        }, {
+            "Move": "Peck",
+            "level": 1
+        }, {
+            "Move": "Leer",
+            "level": 9
+        }, {
+            "Move": "Fury Attack",
+            "level": 15
+        }, {
+            "Move": "Mirror Move",
+            "level": 22
+        }, {
+            "Move": "Drill Peck",
+            "level": 29
+        }, {
+            "Move": "Agility",
+            "level": 36
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Razor Wind",
+            "level": 2
+        }, {
+            "Move": "Whirlwind",
+            "level": 4
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Sky Attack",
+            "level": 43
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Squirtle": {
+    "label": "Tiny Turtle",
+    "sprite": "water",
+    "info": [
+        "After birth, its back swells and hardens into a shell. Powerfully sprays foam from its mouth."
+    ],
+    "evolvesInto": "Wartortle",
+    "evolvesVia": "Level 16",
+    "number": 007,
+    "height": ["1", "8"],
+    "weight": 19.8,
+    "types": ["Water"],
+    "HP": 44,
+    "Attack": 48,
+    "Defense": 65,
+    "Special": 50,
+    "Speed": 43,
+    "moves": {
+        "natural": [{
+            "Move": "Tackle",
+            "level": 1
+        }, {
+            "Move": "Tail Whip",
+            "level": 1
+        }, {
+            "Move": "Bubble",
+            "level": 8
+        }, {
+            "Move": "Water Gun",
+            "level": 15
+        }, {
+            "Move": "Bite",
+            "level": 22
+        }, {
+            "Move": "Withdraw",
+            "level": 28
+        }, {
+            "Move": "Skull Bash",
+            "level": 35
+        }, {
+            "Move": "Hydro Pump",
+            "level": 42
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Mega Punch",
+            "level": 1
+        }, {
+            "Move": "Mega Kick",
+            "level": 5
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Bubble Beam",
+            "level": 11
+        }, {
+            "Move": "Water Gun",
+            "level": 12
+        }, {
+            "Move": "Ice Beam",
+            "level": 13
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Counter",
+            "level": 18
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Dig",
+            "level": 28
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Starmie": {
+    "label": "Mysterious",
+    "sprite": "water",
+    "info": [
+        "Its central core glows with the seven colors of the rainbow. Some people value the core as a gem."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 121,
+    "height": ["3", "7"],
+    "weight": 176.4,
+    "types": ["Water", "Psychic"],
+    "HP": 60,
+    "Attack": 75,
+    "Defense": 85,
+    "Special": 100,
+    "Speed": 115,
+    "moves": {
+        "natural": [{
+            "Move": "Harden",
+            "level": 1
+        }, {
+            "Move": "Tackle",
+            "level": 1
+        }, {
+            "Move": "Water Gun",
+            "level": 1
+        }],
+        "hm": [{
+            "Move": "Surf",
+            "level": 3
+        }, {
+            "Move": "Flash",
+            "level": 5
+        }],
+        "tm": [{
+            "Move": "Surf",
+            "level": 3
+        }, {
+            "Move": "Flash",
+            "level": 5
+        }]
+    }
+}, "Staryu": {
+    "label": "Star Shape",
+    "sprite": "water",
+    "info": [
+        "An enigmatic POKÃ©MON that can effortlessly regenerate any appendage it loses in battle."
+    ],
+    "evolvesInto": "Starmie",
+    "evolvesVia": "use Water Stone",
+    "number": 120,
+    "height": ["2", "7"],
+    "weight": 76.1,
+    "types": ["Water"],
+    "HP": 30,
+    "Attack": 45,
+    "Defense": 55,
+    "Special": 70,
+    "Speed": 85,
+    "moves": {
+        "natural": [{
+            "Move": "Tackle",
+            "level": 1
+        }, {
+            "Move": "Water Gun",
+            "level": 17
+        }, {
+            "Move": "Harden",
+            "level": 22
+        }, {
+            "Move": "Recover",
+            "level": 27
+        }, {
+            "Move": "Swift",
+            "level": 32
+        }, {
+            "Move": "Minimize",
+            "level": 37
+        }, {
+            "Move": "Light Screen",
+            "level": 42
+        }, {
+            "Move": "Hydro Pump",
+            "level": 47
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Bubble Beam",
+            "level": 11
+        }, {
+            "Move": "Water Gun",
+            "level": 12
+        }, {
+            "Move": "Ice Beam",
+            "level": 13
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Thunderbolt",
+            "level": 24
+        }, {
+            "Move": "Thunder",
+            "level": 25
+        }, {
+            "Move": "Psychic",
+            "level": 29
+        }, {
+            "Move": "Teleport",
+            "level": 30
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Thunder Wave",
+            "level": 45
+        }, {
+            "Move": "Psywave",
+            "level": 46
+        }, {
+            "Move": "Tri Attack",
+            "level": 49
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Tangela": {
+    "label": "Vine",
+    "sprite": "water",
+    "info": [
+        "The whole body is swathed with wide vines that are similar to seaweed. Its vines shake as it walks."
+    ],
+    "evolvesInto": "Tangrowth",
+    "evolvesVia": "after AncientPowerlearned",
+    "number": 114,
+    "height": ["3", "3"],
+    "weight": 77.2,
+    "types": ["Grass"],
+    "HP": 65,
+    "Attack": 55,
+    "Defense": 115,
+    "Special": 100,
+    "Speed": 60,
+    "moves": {
+        "natural": [{
+            "Move": "Bind",
+            "level": 1
+        }, {
+            "Move": "Constrict",
+            "level": 1
+        }, {
+            "Move": "Absorb",
+            "level": 29
+        }, {
+            "Move": "Poison Powder",
+            "level": 32
+        }, {
+            "Move": "Stun Spore",
+            "level": 36
+        }, {
+            "Move": "Sleep Powder",
+            "level": 39
+        }, {
+            "Move": "Slam",
+            "level": 45
+        }, {
+            "Move": "Growth",
+            "level": 49
+        }],
+        "hm": [{
+            "Move": "Cut",
+            "level": 1
+        }],
+        "tm": [{
+            "Move": "Swords Dance",
+            "level": 3
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mega Drain",
+            "level": 21
+        }, {
+            "Move": "Solar Beam",
+            "level": 22
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Tauros": {
+    "label": "Wild Bull",
+    "sprite": "water",
+    "info": [
+        "When it targets an enemy, it charges furiously while whipping its body with its long tails."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 128,
+    "height": ["4", "7"],
+    "weight": 194.9,
+    "types": ["Normal"],
+    "HP": 75,
+    "Attack": 100,
+    "Defense": 95,
+    "Special": 40,
+    "Speed": 110,
+    "moves": {
+        "natural": [{
+            "Move": "Tackle",
+            "level": 1
+        }, {
+            "Move": "Stomp",
+            "level": 21
+        }, {
+            "Move": "Tail Whip",
+            "level": 28
+        }, {
+            "Move": "Leer",
+            "level": 35
+        }, {
+            "Move": "Rage",
+            "level": 44
+        }, {
+            "Move": "Take Down",
+            "level": 51
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Horn Drill",
+            "level": 7
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Ice Beam",
+            "level": 13
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Thunderbolt",
+            "level": 24
+        }, {
+            "Move": "Thunder",
+            "level": 25
+        }, {
+            "Move": "Earthquake",
+            "level": 26
+        }, {
+            "Move": "Fissure",
+            "level": 27
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Fire Blast",
+            "level": 38
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Tentacool": {
+    "label": "Jellyfish",
+    "sprite": "water",
+    "info": [
+        "Drifts in shallow seas. Anglers who hook them by accident are often punished by its stinging acid."
+    ],
+    "evolvesInto": "Tentacruel",
+    "evolvesVia": "Level 30",
+    "number": 072,
+    "height": ["2", "11"],
+    "weight": 100.3,
+    "types": ["Water", "Poison"],
+    "HP": 40,
+    "Attack": 40,
+    "Defense": 35,
+    "Special": 50,
+    "Speed": 70,
+    "moves": {
+        "natural": [{
+            "Move": "Acid",
+            "level": 1
+        }, {
+            "Move": "Supersonic",
+            "level": 7
+        }, {
+            "Move": "Wrap",
+            "level": 13
+        }, {
+            "Move": "Poison Sting",
+            "level": 18
+        }, {
+            "Move": "Water Gun",
+            "level": 22
+        }, {
+            "Move": "Constrict",
+            "level": 27
+        }, {
+            "Move": "Barrier",
+            "level": 33
+        }, {
+            "Move": "Screech",
+            "level": 40
+        }, {
+            "Move": "Hydro Pump",
+            "level": 48
+        }],
+        "hm": [{
+            "Move": "Cut",
+            "level": 1
+        }, {
+            "Move": "Surf",
+            "level": 3
+        }],
+        "tm": [{
+            "Move": "Swords Dance",
+            "level": 3
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Bubble Beam",
+            "level": 11
+        }, {
+            "Move": "Water Gun",
+            "level": 12
+        }, {
+            "Move": "Ice Beam",
+            "level": 13
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mega Drain",
+            "level": 21
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Tentacruel": {
+    "label": "Jellyfish",
+    "sprite": "water",
+    "info": [
+        "The tentacles are normally kept short. On hunts, they are extended to ensnare and immobilize prey."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 073,
+    "height": ["5", "3"],
+    "weight": 121.3,
+    "types": ["Water", "Poison"],
+    "HP": 80,
+    "Attack": 70,
+    "Defense": 65,
+    "Special": 80,
+    "Speed": 100,
+    "moves": {
+        "natural": [{
+            "Move": "Acid",
+            "level": 1
+        }, {
+            "Move": "Supersonic",
+            "level": 1
+        }, {
+            "Move": "Wrap",
+            "level": 1
+        }, {
+            "Move": "Supersonic",
+            "level": 7
+        }, {
+            "Move": "Wrap",
+            "level": 13
+        }, {
+            "Move": "Poison Sting",
+            "level": 18
+        }, {
+            "Move": "Water Gun",
+            "level": 22
+        }, {
+            "Move": "Constrict",
+            "level": 27
+        }, {
+            "Move": "Barrier",
+            "level": 35
+        }, {
+            "Move": "Screech",
+            "level": 43
+        }, {
+            "Move": "Hydro Pump",
+            "level": 50
+        }],
+        "hm": [{
+            "Move": "Cut",
+            "level": 1
+        }, {
+            "Move": "Surf",
+            "level": 3
+        }],
+        "tm": [{
+            "Move": "Swords Dance",
+            "level": 3
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Bubble Beam",
+            "level": 11
+        }, {
+            "Move": "Water Gun",
+            "level": 12
+        }, {
+            "Move": "Ice Beam",
+            "level": 13
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mega Drain",
+            "level": 21
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Vaporeon": {
+    "label": "Bubble Jet",
+    "sprite": "water",
+    "info": [
+        "Lives close to water. Its long tail is ridged with a fin which is often mistaken for a mermaid's."
+    ],
+    "evolvesInto": "Jolteon",
+    "evolvesVia": "↖",
+    "number": 134,
+    "height": ["3", "3"],
+    "weight": 63.9,
+    "types": ["Water"],
+    "HP": 130,
+    "Attack": 65,
+    "Defense": 60,
+    "Special": 110,
+    "Speed": 65,
+    "moves": {
+        "natural": [{
+            "Move": "Quick Attack",
+            "level": 1
+        }, {
+            "Move": "Sand Attack",
+            "level": 1
+        }, {
+            "Move": "Tackle",
+            "level": 1
+        }, {
+            "Move": "Water Gun",
+            "level": 1
+        }, {
+            "Move": "Quick Attack",
+            "level": 27
+        }, {
+            "Move": "Water Gun",
+            "level": 31
+        }, {
+            "Move": "Tail Whip",
+            "level": 37
+        }, {
+            "Move": "Bite",
+            "level": 40
+        }, {
+            "Move": "Acid Armor",
+            "level": 42
+        }, {
+            "Move": "Haze",
+            "level": 44
+        }, {
+            "Move": "Mist",
+            "level": 48
+        }, {
+            "Move": "Hydro Pump",
+            "level": 54
+        }],
+        "hm": [{
+            "Move": "Surf",
+            "level": 3
+        }],
+        "tm": [{
+            "Move": "Surf",
+            "level": 3
+        }]
+    }
+}, "Venomoth": {
+    "label": "Poison Moth",
+    "sprite": "water",
+    "info": [
+        "The dust-like scales covering its wings are color coded to indicate the kinds of poison it has."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 049,
+    "height": ["4", "11"],
+    "weight": 27.6,
+    "types": ["Bug", "Poison"],
+    "HP": 70,
+    "Attack": 65,
+    "Defense": 60,
+    "Special": 90,
+    "Speed": 90,
+    "moves": {
+        "natural": [{
+            "Move": "Disable",
+            "level": 1
+        }, {
+            "Move": "Leech Life",
+            "level": 1
+        }, {
+            "Move": "Poison Powder",
+            "level": 1
+        }, {
+            "Move": "Tackle",
+            "level": 1
+        }, {
+            "Move": "Poison Powder",
+            "level": 24
+        }, {
+            "Move": "Leech Life",
+            "level": 27
+        }, {
+            "Move": "Stun Spore",
+            "level": 30
+        }, {
+            "Move": "Psybeam",
+            "level": 38
+        }, {
+            "Move": "Sleep Powder",
+            "level": 43
+        }, {
+            "Move": "Psychic",
+            "level": 50
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Confusion",
+            "level": 1
+        }, {
+            "Move": "Disable",
+            "level": 1
+        }, {
+            "Move": "Supersonic",
+            "level": 1
+        }, {
+            "Move": "Tackle",
+            "level": 1
+        }, {
+            "Move": "Poison Powder",
+            "level": 22
+        }, {
+            "Move": "Leech Life",
+            "level": 27
+        }, {
+            "Move": "Stun Spore",
+            "level": 30
+        }, {
+            "Move": "Psybeam",
+            "level": 38
+        }, {
+            "Move": "Sleep Powder",
+            "level": 43
+        }, {
+            "Move": "Psychic",
+            "level": 50
+        }]
+    }
+}, "Venonat": {
+    "label": "Insect",
+    "sprite": "water",
+    "info": [
+        "Lives in the shadows of tall trees where it eats insects. It is attracted by light at night."
+    ],
+    "evolvesInto": "Venomoth",
+    "evolvesVia": "Level 31",
+    "number": 048,
+    "height": ["3", "3"],
+    "weight": 66.1,
+    "types": ["Bug", "Poison"],
+    "HP": 60,
+    "Attack": 55,
+    "Defense": 50,
+    "Special": 40,
+    "Speed": 45,
+    "moves": {
+        "natural": [{
+            "Move": "Disable",
+            "level": 1
+        }, {
+            "Move": "Tackle",
+            "level": 1
+        }, {
+            "Move": "Poison Powder",
+            "level": 24
+        }, {
+            "Move": "Leech Life",
+            "level": 27
+        }, {
+            "Move": "Stun Spore",
+            "level": 30
+        }, {
+            "Move": "Psybeam",
+            "level": 35
+        }, {
+            "Move": "Sleep Powder",
+            "level": 38
+        }, {
+            "Move": "Psychic",
+            "level": 43
+        }],
+        "hm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mega Drain",
+            "level": 21
+        }, {
+            "Move": "Solar Beam",
+            "level": 22
+        }, {
+            "Move": "Psychic",
+            "level": 29
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Psywave",
+            "level": 46
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }],
+        "tm": [{
+            "Move": "Disable",
+            "level": 1
+        }, {
+            "Move": "Tackle",
+            "level": 1
+        }, {
+            "Move": "Supersonic",
+            "level": 11
+        }, {
+            "Move": "Confusion",
+            "level": 19
+        }, {
+            "Move": "Poison Powder",
+            "level": 22
+        }, {
+            "Move": "Leech Life",
+            "level": 27
+        }, {
+            "Move": "Stun Spore",
+            "level": 30
+        }, {
+            "Move": "Psybeam",
+            "level": 35
+        }, {
+            "Move": "Sleep Powder",
+            "level": 38
+        }, {
+            "Move": "Psychic",
+            "level": 43
+        }]
+    }
+}, "Venusaur": {
+    "label": "Seed",
+    "sprite": "water",
+    "info": [
+        "The plant blooms when it is absorbing solar energy. It stays on the move to seek sunlight."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 003,
+    "height": ["6", "7"],
+    "weight": 220.5,
+    "types": ["Grass", "Poison"],
+    "HP": 80,
+    "Attack": 82,
+    "Defense": 83,
+    "Special": 100,
+    "Speed": 80,
+    "moves": {
+        "natural": [{
+            "Move": "Growl",
+            "level": 1
+        }, {
+            "Move": "Leech Seed",
+            "level": 1
+        }, {
+            "Move": "Tackle",
+            "level": 1
+        }, {
+            "Move": "Vine Whip",
+            "level": 1
+        }, {
+            "Move": "Leech Seed",
+            "level": 7
+        }, {
+            "Move": "Vine Whip",
+            "level": 13
+        }, {
+            "Move": "Poison Powder",
+            "level": 22
+        }, {
+            "Move": "Razor Leaf",
+            "level": 30
+        }, {
+            "Move": "Growth",
+            "level": 43
+        }, {
+            "Move": "Sleep Powder",
+            "level": 55
+        }, {
+            "Move": "Solar Beam",
+            "level": 65
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Swords Dance",
+            "level": 3
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mega Drain",
+            "level": 21
+        }, {
+            "Move": "Solar Beam",
+            "level": 22
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Victreebel": {
+    "label": "Flycatcher",
+    "sprite": "water",
+    "info": [
+        "Said to live in huge colonies deep in jungles, although no one has ever returned from there."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 071,
+    "height": ["5", "7"],
+    "weight": 34.2,
+    "types": ["Grass", "Poison"],
+    "HP": 80,
+    "Attack": 105,
+    "Defense": 65,
+    "Special": 100,
+    "Speed": 70,
+    "moves": {
+        "natural": [{
+            "Move": "Acid",
+            "level": 1
+        }, {
+            "Move": "Razor Leaf",
+            "level": 1
+        }, {
+            "Move": "Sleep Powder",
+            "level": 1
+        }, {
+            "Move": "Stun Spore",
+            "level": 1
+        }, {
+            "Move": "Wrap",
+            "level": 13
+        }, {
+            "Move": "Poison Powder",
+            "level": 15
+        }, {
+            "Move": "Sleep Powder",
+            "level": 18
+        }],
+        "hm": [{
+            "Move": "Cut",
+            "level": 1
+        }],
+        "tm": [{
+            "Move": "Cut",
+            "level": 1
+        }]
+    }
+}, "Vileplume": {
+    "label": "Flower",
+    "sprite": "water",
+    "info": [
+        "The larger its petals, the more toxic pollen it contains. Its big head is heavy and hard to hold up."
+    ],
+    "evolvesInto": "Bellossom",
+    "evolvesVia": "use Sun Stone",
+    "number": 045,
+    "height": ["3", "11"],
+    "weight": 41,
+    "types": ["Grass", "Poison"],
+    "HP": 75,
+    "Attack": 80,
+    "Defense": 85,
+    "Special": 110,
+    "Speed": 50,
+    "moves": {
+        "natural": [{
+            "Move": "Acid",
+            "level": 1
+        }, {
+            "Move": "Petal Dance",
+            "level": 1
+        }, {
+            "Move": "Sleep Powder",
+            "level": 1
+        }, {
+            "Move": "Stun Spore",
+            "level": 1
+        }, {
+            "Move": "Poison Powder",
+            "level": 15
+        }, {
+            "Move": "Stun Spore",
+            "level": 17
+        }, {
+            "Move": "Sleep Powder",
+            "level": 19
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Cut",
+            "level": 1
+        }]
+    }
+}, "Voltorb": {
+    "label": "Ball",
+    "sprite": "water",
+    "info": [
+        "Usually found in power plants. Easily mistaken for a POKÃ© BALL, they have zapped many people."
+    ],
+    "evolvesInto": "Electrode",
+    "evolvesVia": "Level 30",
+    "number": 100,
+    "height": ["1", "8"],
+    "weight": 22.9,
+    "types": ["Electric"],
+    "HP": 40,
+    "Attack": 30,
+    "Defense": 50,
+    "Special": 55,
+    "Speed": 100,
+    "moves": {
+        "natural": [{
+            "Move": "Screech",
+            "level": 1
+        }, {
+            "Move": "Tackle",
+            "level": 1
+        }, {
+            "Move": "Sonic Boom",
+            "level": 17
+        }, {
+            "Move": "Self-Destruct",
+            "level": 22
+        }, {
+            "Move": "Light Screen",
+            "level": 29
+        }, {
+            "Move": "Swift",
+            "level": 36
+        }, {
+            "Move": "Explosion",
+            "level": 43
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Thunderbolt",
+            "level": 24
+        }, {
+            "Move": "Thunder",
+            "level": 25
+        }, {
+            "Move": "Teleport",
+            "level": 30
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Self-Destruct",
+            "level": 36
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Thunder Wave",
+            "level": 45
+        }, {
+            "Move": "Explosion",
+            "level": 47
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Vulpix": {
+    "label": "Fox",
+    "sprite": "water",
+    "info": [
+        "At the time of birth, it has just one tail. The tail splits from its tip as it grows older."
+    ],
+    "evolvesInto": "Ninetales",
+    "evolvesVia": "use Fire Stone",
+    "number": 037,
+    "height": ["2", "0"],
+    "weight": 21.8,
+    "types": ["Fire"],
+    "HP": 38,
+    "Attack": 41,
+    "Defense": 40,
+    "Special": 50,
+    "Speed": 65,
+    "moves": {
+        "natural": [{
+            "Move": "Ember",
+            "level": 1
+        }, {
+            "Move": "Tail Whip",
+            "level": 1
+        }, {
+            "Move": "Quick Attack",
+            "level": 16
+        }, {
+            "Move": "Roar",
+            "level": 21
+        }, {
+            "Move": "Confuse Ray",
+            "level": 28
+        }, {
+            "Move": "Flamethrower",
+            "level": 35
+        }, {
+            "Move": "Fire Spin",
+            "level": 42
+        }],
+        "hm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Dig",
+            "level": 28
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Fire Blast",
+            "level": 38
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }],
+        "tm": [{
+            "Move": "Ember",
+            "level": 1
+        }, {
+            "Move": "Tail Whip",
+            "level": 1
+        }, {
+            "Move": "Quick Attack",
+            "level": 16
+        }, {
+            "Move": "Roar",
+            "level": 21
+        }, {
+            "Move": "Confuse Ray",
+            "level": 28
+        }, {
+            "Move": "Flamethrower",
+            "level": 35
+        }, {
+            "Move": "Fire Spin",
+            "level": 42
+        }]
+    }
+}, "Wartortle": {
+    "label": "Turtle",
+    "sprite": "water",
+    "info": [
+        "Often hides in water to stalk unwary prey. For swimming fast, it moves its ears to maintain balance."
+    ],
+    "evolvesInto": "Blastoise",
+    "evolvesVia": "Level 36",
+    "number": 008,
+    "height": ["3", "3"],
+    "weight": 49.6,
+    "types": ["Water"],
+    "HP": 59,
+    "Attack": 63,
+    "Defense": 80,
+    "Special": 65,
+    "Speed": 58,
+    "moves": {
+        "natural": [{
+            "Move": "Bubble",
+            "level": 1
+        }, {
+            "Move": "Tackle",
+            "level": 1
+        }, {
+            "Move": "Tail Whip",
+            "level": 1
+        }, {
+            "Move": "Bubble",
+            "level": 8
+        }, {
+            "Move": "Water Gun",
+            "level": 15
+        }, {
+            "Move": "Bite",
+            "level": 24
+        }, {
+            "Move": "Withdraw",
+            "level": 31
+        }, {
+            "Move": "Skull Bash",
+            "level": 39
+        }, {
+            "Move": "Hydro Pump",
+            "level": 47
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Mega Punch",
+            "level": 1
+        }, {
+            "Move": "Mega Kick",
+            "level": 5
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Body Slam",
+            "level": 8
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Bubble Beam",
+            "level": 11
+        }, {
+            "Move": "Water Gun",
+            "level": 12
+        }, {
+            "Move": "Ice Beam",
+            "level": 13
+        }, {
+            "Move": "Blizzard",
+            "level": 14
+        }, {
+            "Move": "Submission",
+            "level": 17
+        }, {
+            "Move": "Counter",
+            "level": 18
+        }, {
+            "Move": "Seismic Toss",
+            "level": 19
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Dig",
+            "level": 28
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Skull Bash",
+            "level": 40
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Weedle": {
+    "label": "Hairy Bug",
+    "sprite": "water",
+    "info": [
+        "Often found in forests, eating leaves. It has a sharp venomous stinger on its head."
+    ],
+    "evolvesInto": "Kakuna",
+    "evolvesVia": "Level 7",
+    "number": 013,
+    "height": ["1", "0"],
+    "weight": 7.1,
+    "types": ["Bug", "Poison"],
+    "HP": 40,
+    "Attack": 35,
+    "Defense": 30,
+    "Special": 20,
+    "Speed": 50,
+    "moves": {
+        "natural": [{
+            "Move": "Poison Sting",
+            "level": 1
+        }, {
+            "Move": "String Shot",
+            "level": 1
+        }],
+        "hm": [],
+        "tm": []
+    }
+}, "Weepinbell": {
+    "label": "Flycatcher",
+    "sprite": "water",
+    "info": [
+        "It spits out POISONPOWDER to immobilize the enemy and then finishes it with a spray of ACID."
+    ],
+    "evolvesInto": "Victreebel",
+    "evolvesVia": "use Leaf Stone",
+    "number": 070,
+    "height": ["3", "3"],
+    "weight": 14.1,
+    "types": ["Grass", "Poison"],
+    "HP": 65,
+    "Attack": 90,
+    "Defense": 50,
+    "Special": 85,
+    "Speed": 55,
+    "moves": {
+        "natural": [{
+            "Move": "Growth",
+            "level": 1
+        }, {
+            "Move": "Vine Whip",
+            "level": 1
+        }, {
+            "Move": "Wrap",
+            "level": 1
+        }, {
+            "Move": "Wrap",
+            "level": 13
+        }, {
+            "Move": "Poison Powder",
+            "level": 15
+        }, {
+            "Move": "Sleep Powder",
+            "level": 18
+        }, {
+            "Move": "Stun Spore",
+            "level": 23
+        }, {
+            "Move": "Acid",
+            "level": 29
+        }, {
+            "Move": "Razor Leaf",
+            "level": 38
+        }, {
+            "Move": "Slam",
+            "level": 49
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Swords Dance",
+            "level": 3
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Mega Drain",
+            "level": 21
+        }, {
+            "Move": "Solar Beam",
+            "level": 22
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Weezing": {
+    "label": "Poison Gas",
+    "sprite": "water",
+    "info": [
+        "Where two kinds of poison gases meet, 2 KOFFINGs can fuse into a WEEZING over many years."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 110,
+    "height": ["3", "11"],
+    "weight": 20.9,
+    "types": ["Poison"],
+    "HP": 65,
+    "Attack": 90,
+    "Defense": 120,
+    "Special": 85,
+    "Speed": 60,
+    "moves": {
+        "natural": [{
+            "Move": "Sludge",
+            "level": 1
+        }, {
+            "Move": "Smog",
+            "level": 1
+        }, {
+            "Move": "Tackle",
+            "level": 1
+        }, {
+            "Move": "Sludge",
+            "level": 32
+        }, {
+            "Move": "Smokescreen",
+            "level": 39
+        }, {
+            "Move": "Self-Destruct",
+            "level": 43
+        }, {
+            "Move": "Haze",
+            "level": 49
+        }, {
+            "Move": "Explosion",
+            "level": 53
+        }],
+        "hm": [{
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Thunderbolt",
+            "level": 24
+        }, {
+            "Move": "Thunder",
+            "level": 25
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Self-Destruct",
+            "level": 36
+        }, {
+            "Move": "Fire Blast",
+            "level": 38
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Explosion",
+            "level": 47
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }],
+        "tm": [{
+            "Move": "Sludge",
+            "level": 1
+        }, {
+            "Move": "Smog",
+            "level": 1
+        }, {
+            "Move": "Tackle",
+            "level": 1
+        }, {
+            "Move": "Sludge",
+            "level": 32
+        }, {
+            "Move": "Smokescreen",
+            "level": 39
+        }, {
+            "Move": "Self-Destruct",
+            "level": 43
+        }, {
+            "Move": "Haze",
+            "level": 49
+        }, {
+            "Move": "Explosion",
+            "level": 53
+        }]
+    }
+}, "Wigglytuff": {
+    "label": "Balloon",
+    "sprite": "water",
+    "info": [
+        "The body is soft and rubbery. When angered, it will suck in air and inflate itself to an enormous size."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 040,
+    "height": ["3", "3"],
+    "weight": 26.5,
+    "types": ["Normal", "Fairy"],
+    "HP": 140,
+    "Attack": 70,
+    "Defense": 45,
+    "Special": 85,
+    "Speed": 45,
+    "moves": {
+        "natural": [{
+            "Move": "Defense Curl",
+            "level": 1
+        }, {
+            "Move": "Disable",
+            "level": 1
+        }, {
+            "Move": "Double Slap",
+            "level": 1
+        }, {
+            "Move": "Sing",
+            "level": 1
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Strength",
+            "level": 4
+        }, {
+            "Move": "Flash",
+            "level": 5
+        }]
+    }
+}, "Zapdos": {
+    "label": "Electric",
+    "sprite": "water",
+    "info": [
+        "A legendary bird POKÃ©MON that is said to appear from clouds while dropping enormous lightning bolts."
+    ],
+    "evolvesInto": "Undefined",
+    "evolvesVia": "Undefined",
+    "number": 145,
+    "height": ["5", "3"],
+    "weight": 116,
+    "types": ["Electric", "Flying"],
+    "HP": 90,
+    "Attack": 90,
+    "Defense": 85,
+    "Special": 125,
+    "Speed": 100,
+    "moves": {
+        "natural": [{
+            "Move": "Drill Peck",
+            "level": 1
+        }, {
+            "Move": "Thunder Shock",
+            "level": 1
+        }, {
+            "Move": "Thunder",
+            "level": 51
+        }, {
+            "Move": "Agility",
+            "level": 55
+        }, {
+            "Move": "Light Screen",
+            "level": 60
+        }],
+        "hm": [{
+            "Move": "Fly",
+            "level": 2
+        }, {
+            "Move": "Flash",
+            "level": 5
+        }],
+        "tm": [{
+            "Move": "Razor Wind",
+            "level": 2
+        }, {
+            "Move": "Whirlwind",
+            "level": 4
+        }, {
+            "Move": "Toxic",
+            "level": 6
+        }, {
+            "Move": "Take Down",
+            "level": 9
+        }, {
+            "Move": "Double-Edge",
+            "level": 10
+        }, {
+            "Move": "Hyper Beam",
+            "level": 15
+        }, {
+            "Move": "Rage",
+            "level": 20
+        }, {
+            "Move": "Thunderbolt",
+            "level": 24
+        }, {
+            "Move": "Thunder",
+            "level": 25
+        }, {
+            "Move": "Mimic",
+            "level": 31
+        }, {
+            "Move": "Double Team",
+            "level": 32
+        }, {
+            "Move": "Reflect",
+            "level": 33
+        }, {
+            "Move": "Bide",
+            "level": 34
+        }, {
+            "Move": "Swift",
+            "level": 39
+        }, {
+            "Move": "Sky Attack",
+            "level": 43
+        }, {
+            "Move": "Rest",
+            "level": 44
+        }, {
+            "Move": "Thunder Wave",
+            "level": 45
+        }, {
+            "Move": "Substitute",
+            "level": 50
+        }]
+    }
+}, "Zubat": {
+    "label": "Bat",
+    "sprite": "water",
+    "info": [
+        "Forms colonies in perpetually dark places. Uses ultrasonic waves to identify and approach targets."
+    ],
+    "evolvesInto": "Golbat",
+    "evolvesVia": "Level 22",
+    "number": 041,
+    "height": ["2", "7"],
+    "weight": 16.5,
+    "types": ["Poison", "Flying"],
+    "HP": 40,
+    "Attack": 45,
+    "Defense": 35,
+    "Special": 30,
+    "Speed": 55,
+    "moves": {
+        "natural": [{
+            "Move": "Leech Life",
+            "level": 1
+        }, {
+            "Move": "Supersonic",
+            "level": 10
+        }, {
+            "Move": "Bite",
+            "level": 15
+        }, {
+            "Move": "Confuse Ray",
+            "level": 21
+        }, {
+            "Move": "Wing Attack",
+            "level": 28
+        }, {
+            "Move": "Haze",
+            "level": 36
+        }],
+        "hm": [],
+        "tm": [{
+            "Move": "Leech Life",
+            "level": 1
+        }, {
+            "Move": "Supersonic",
+            "level": 10
+        }, {
+            "Move": "Bite",
+            "level": 15
+        }, {
+            "Move": "Confuse Ray",
+            "level": 21
+        }, {
+            "Move": "Wing Attack",
+            "level": 28
+        }, {
+            "Move": "Haze",
+            "level": 36
+        }]
+    }
+}
         },
         /**
          * Run on http://www.smogon.com/dex/rb/moves/


### PR DESCRIPTION
I’m pretty sure there a few edge cases I haven’t caught, but we can
work those out as they come up. I double checked pokemon you’ll see
outside of pallet/viridian and they’re all ok, so we should be good to
go for that release. “sprite” attribute still will need to be updated
manually