### PR TITLE
Fixed player walking intervals with canKeyWalking

### DIFF
--- a/Source/FullScreenPokemon.js
+++ b/Source/FullScreenPokemon.js
@@ -635,15 +635,19 @@ var FullScreenPokemon;
                     thing.turning = direction;
                 }
                 if (thing.player) {
-                    if (thing.canKeyWalking) {
-                        thing.FSP.setPlayerDirection(thing, direction);
-                    }
-                    else {
-                        thing.nextDirection = direction;
-                    }
+                    thing.FSP.keyDownDirectionRealPlayer(thing, direction);
                 }
             }
             thing.FSP.ModAttacher.fireEvent("onKeyDownDirectionReal", direction);
+        };
+        FullScreenPokemon.prototype.keyDownDirectionRealPlayer = function (player, direction) {
+            if (player.canKeyWalking && !player.shouldWalk) {
+                player.FSP.setPlayerDirection(player, direction);
+                player.canKeyWalking = false;
+            }
+            else {
+                player.nextDirection = direction;
+            }
         };
         /**
          * Reacts to the A key being pressed. The MenuGraphr's active menu reacts to

--- a/Source/FullScreenPokemon.ts
+++ b/Source/FullScreenPokemon.ts
@@ -896,15 +896,20 @@ module FullScreenPokemon {
                 }
 
                 if (thing.player) {
-                    if ((<IPlayer>thing).canKeyWalking) {
-                        thing.FSP.setPlayerDirection(<IPlayer>thing, direction);
-                    } else {
-                        (<IPlayer>thing).nextDirection = direction;
-                    }
+                    thing.FSP.keyDownDirectionRealPlayer(<IPlayer>thing, direction);
                 }
             }
 
             thing.FSP.ModAttacher.fireEvent("onKeyDownDirectionReal", direction);
+        }
+
+        keyDownDirectionRealPlayer(player: IPlayer, direction: Direction): void {
+            if (player.canKeyWalking && !player.shouldWalk) {
+                player.FSP.setPlayerDirection(player, direction);
+                player.canKeyWalking = false;
+            } else {
+                player.nextDirection = direction;
+            }
         }
 
         /**


### PR DESCRIPTION
keyDownDirectionRealPlayer now more-correctly checks if the player
should be able to trigger a setPlayerDirection.