### PR TITLE
Fix for canKeyWalking being false after a battle

### DIFF
--- a/Source/FullScreenPokemon.js
+++ b/Source/FullScreenPokemon.js
@@ -1744,6 +1744,7 @@ var FullScreenPokemon;
          */
         FullScreenPokemon.prototype.animatePlayerStopWalking = function (thing, onStop) {
             if (thing.FSP.checkPlayerGrassBattle(thing)) {
+                thing.canKeyWalking = true;
                 return false;
             }
             if (thing.following) {

--- a/Source/FullScreenPokemon.ts
+++ b/Source/FullScreenPokemon.ts
@@ -2326,6 +2326,7 @@ module FullScreenPokemon {
          */
         animatePlayerStopWalking(thing: IPlayer, onStop: IWalkingOnStop): boolean {
             if (thing.FSP.checkPlayerGrassBattle(thing)) {
+                thing.canKeyWalking = true;
                 return false;
             }
 


### PR DESCRIPTION
This bug was hard to run into at first. Usually doesn't happen near the beginning of Pallet Town. I first experienced this bug right before you battle the Rival for the second time. After implementing the fix, I ran into under one hundred wild battles and could always move after either fighting the battles or running away.

Fixes #264 