### PR TITLE
Brought in cleaner BattleMovr

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "stringfilr": "^0.5.2",
     "mapscreenr": "^0.5.2",
     "itemsholdr": "^0.5.2",
-    "battlemovr": "^0.5.1",
+    "battlemovr": "^0.5.2",
     "devicelayr": "^0.5.1",
     "eightbittr": "^0.5.2",
     "audioplayr": "^0.5.1",

--- a/shenanigans.json
+++ b/shenanigans.json
@@ -4,7 +4,7 @@
     "StringFilr": "^0.5.2",
     "MapScreenr": "^0.5.2",
     "ItemsHoldr": "^0.5.2",
-    "BattleMovr": "^0.5.1",
+    "BattleMovr": "^0.5.2",
     "DeviceLayr": "^0.5.1",
     "EightBittr": "^0.5.2",
     "AudioPlayr": "^0.5.1",

--- a/src/Animations.ts
+++ b/src/Animations.ts
@@ -253,11 +253,13 @@ export class Animations<TEightBittr extends FullScreenPokemon> extends EightBitt
         this.animateCharacterPreventWalking(thing);
 
         this.EightBitter.battles.startBattle({
-            opponent: {
-                name: chosen.title,
-                actors: [chosenPokemon],
-                category: "Wild",
-                sprite: chosen.title.join("") + "Front"
+            battlers: {
+                opponent: {
+                    name: chosen.title,
+                    actors: [chosenPokemon],
+                    category: "Wild",
+                    sprite: chosen.title.join("") + "Front"
+                }
             }
         });
     }
@@ -273,16 +275,18 @@ export class Animations<TEightBittr extends FullScreenPokemon> extends EightBitt
         const battleSprite: string = other.battleSprite || battleName;
 
         this.EightBitter.battles.startBattle({
-            opponent: {
-                name: battleName.split(""),
-                sprite: battleSprite + "Front",
-                category: "Trainer",
-                hasActors: true,
-                reward: other.reward,
-                actors: other.actors.map(
-                    (schema: IWildPokemonSchema): IPokemon => {
-                        return this.EightBitter.utilities.createPokemon(schema);
-                    })
+            battlers: {
+                opponent: {
+                    name: battleName.split(""),
+                    sprite: battleSprite + "Front",
+                    category: "Trainer",
+                    hasActors: true,
+                    reward: other.reward,
+                    actors: other.actors.map(
+                        (schema: IWildPokemonSchema): IPokemon => {
+                            return this.EightBitter.utilities.createPokemon(schema);
+                        })
+                }
             },
             textStart: ["", " wants to fight!"],
             textDefeat: other.textDefeat,

--- a/src/Fishing.ts
+++ b/src/Fishing.ts
@@ -78,11 +78,13 @@ export class Fishing<TEightBittr extends FullScreenPokemon> extends EightBittr.C
                     ],
                     (): void => {
                         this.EightBitter.battles.startBattle({
-                            opponent: {
-                                name: chosenPokemon.title,
-                                actors: [chosenPokemon],
-                                category: "Wild",
-                                sprite: chosenPokemon.title.join("") + "Front"
+                            battlers: {
+                                opponent: {
+                                    name: chosenPokemon.title,
+                                    actors: [chosenPokemon],
+                                    category: "Wild",
+                                    sprite: chosenPokemon.title.join("") + "Front"
+                                }
                             }
                         });
                     });

--- a/src/FullScreenPokemon.ts
+++ b/src/FullScreenPokemon.ts
@@ -326,8 +326,32 @@ export class FullScreenPokemon extends GameStartr.GameStartr {
             this.utilities.proliferate(
                 {
                     GameStarter: this,
-                    openItemsMenuCallback: this.menus.openItemsMenu.bind(this.menus),
-                    openActorsMenuCallback: this.menus.openPokemonMenu.bind(this.menus)
+                    battleOptions: [
+                        {
+                            text: "FIGHT",
+                            callback: (): void => {
+                                this.battles.openBattleMovesMenu();
+                            }
+                        },
+                        {
+                            text: "ITEM",
+                            callback: (): void => {
+                                this.battles.openBattleItemsMenu();
+                            }
+                        },
+                        {
+                            text: ["Poke", "Mon"],
+                            callback: (): void => {
+                                this.battles.openBattlePokemonMenu();
+                            }
+                        },
+                        {
+                            text: "RUN",
+                            callback: (): void => {
+                                this.battles.startBattleExit();
+                            }
+                        }
+                    ]
                 },
                 this.settings.battles));
     }

--- a/src/IFullScreenPokemon.ts
+++ b/src/IFullScreenPokemon.ts
@@ -75,11 +75,11 @@ export interface IThingsById {
 /**
  * Settings regarding in-game battles, particularly for an IBattleMovr.
  */
-export interface IBattleMovrCustoms extends GameStartr.IGameStartrSettingsObject {
+export interface IBattleMovrCustoms extends BattleMovr.IBattleMovrSettings, GameStartr.IGameStartrSettingsObject {
     /**
      * The IMenuGraphr handling menu creation.
      */
-    MenuGrapher: MenuGraphr.IMenuGraphr;
+    MenuGrapher?: MenuGraphr.IMenuGraphr;
 }
 
 /**
@@ -293,7 +293,11 @@ export interface IMathEquations extends MathDecidr.IEquations {
      * @param level   The level of the Pokemon.
      * @returns How much experience the Pokemon should start with.
      */
-    newPokemonExperience: (constants: IMathConstants, equations: IMathEquations, title: string[], level: number) => IExperience;
+    newPokemonExperience: (
+        constants: IMathConstants,
+        equations: IMathEquations,
+        title: string[],
+        level: number) => BattleMovr.IActorExperience;
 
     /**
      * Computes a Pokemon's new statistic based on its IVs and EVs.
@@ -366,8 +370,8 @@ export interface IMathEquations extends MathDecidr.IEquations {
     opponentMove: (
         constants: IMathConstants,
         equations: IMathEquations,
-        player: IBattleThingInfo,
-        opponent: IBattleThingInfo) => string;
+        player: IBattler,
+        opponent: IBattler) => string;
 
     /**
      * Checks whether a Pokemon contains any of the given types.
@@ -422,9 +426,9 @@ export interface IMathEquations extends MathDecidr.IEquations {
     playerMovesFirst: (
         constants: IMathConstants,
         equations: IMathEquations,
-        player: IBattleThingInfo,
+        player: IBattler,
         choicePlayer: string,
-        opponent: IBattleThingInfo,
+        opponent: IBattler,
         choiceOpponent: string) => boolean;
 
     /**
@@ -504,8 +508,8 @@ export interface IMathEquations extends MathDecidr.IEquations {
     experienceGained: (
         constants: IMathConstants,
         equations: IMathEquations,
-        player: IBattleThingInfo,
-        opponent: IBattleThingInfo) => number;
+        player: IBattler,
+        opponent: IBattler) => number;
 
     /**
      * Computes how wide a health bar should be.
@@ -1351,6 +1355,11 @@ export interface IBattleInfo extends BattleMovr.IBattleInfo {
     badge?: string;
 
     /**
+     * 
+     */
+    battlers: IBattlers;
+
+    /**
      * How many times the player has attempted to flee.
      */
     currentEscapeAttempts?: number;
@@ -1379,16 +1388,6 @@ export interface IBattleInfo extends BattleMovr.IBattleInfo {
      * A callback for after showing the player menu.
      */
     onShowPlayerMenu?: () => void;
-
-    /**
-     * The opponent, including its actors (Pokemon) and settings.
-     */
-    opponent?: IBattleThingInfo;
-
-    /**
-     * The player, including its actors (Pokemon) and settings.
-     */
-    player?: IBattleThingInfo;
 
     /**
      * Text to display after a battle victory when in the real world again.
@@ -1429,9 +1428,26 @@ export interface IBattleInfo extends BattleMovr.IBattleInfo {
 }
 
 /**
+ * 
+ */
+export interface IBattlers extends BattleMovr.IBattlers {
+        /**
+         * The opponent battler's information.
+         */
+        opponent?: IBattler;
+
+        /**
+         * The player's battle information.
+         */
+        player?: IBattler;
+
+        [i: string]: IBattler;
+}
+
+/**
  * A trainer in battle, namely either the player or opponent.
  */
-export interface IBattleThingInfo extends BattleMovr.IBattleThingInfo {
+export interface IBattler extends BattleMovr.IBattler {
     /**
      * The trainer's available Pokemon.
      */
@@ -1458,6 +1474,111 @@ export interface IBattleThingInfo extends BattleMovr.IBattleThingInfo {
  */
 export interface IPokemon extends BattleMovr.IActor {
     /**
+     * Current (in-battle) Attack.
+     */
+    Attack: number;
+
+    /**
+     * Default Attack.
+     */
+    AttackNormal: number;
+
+    /**
+     * Current (in-battle) Defense.
+     */
+    Defense: number;
+
+    /**
+     * Default Defense.
+     */
+    DefenseNormal: number;
+
+    /**
+     * Accumulated effort value points.
+     */
+    EV: {
+        /**
+         * Attack EV points.
+         */
+        Attack: number;
+
+        /**
+         * Defense EV points.
+         */
+        Defense: number;
+
+        /**
+         * Special EV points.
+         */
+        Special: number;
+
+        /**
+         * Speed EV points.
+         */
+        Speed: number;
+    };
+
+    /**
+     * Current (in-battle) HP.
+     */
+    HP: number;
+
+    /**
+     * Default HP.
+     */
+    HPNormal: number;
+
+    /**
+     * Accumulated individual value points.
+     */
+    IV: {
+        /**
+         * Attack IV points.
+         */
+        Attack: number;
+
+        /**
+         * Defense IV points.
+         */
+        Defense: number;
+
+        /**
+         * HP IV points.
+         */
+        HP: number;
+
+        /**
+         * Special IV points.
+         */
+        Special: number;
+
+        /**
+         * Speed IV points.
+         */
+        Speed: number;
+    };
+
+    /**
+     * Current (in-battle) Special.
+     */
+    Special: number;
+
+    /**
+     * Default Special.
+     */
+    SpecialNormal: number;
+
+    /**
+     * Current (in-battle) Speed.
+     */
+    Speed: number;
+
+    /**
+     * Default Speed.
+     */
+    SpeedNormal: number;
+
+    /**
      * How difficult this is to catch, for the canCatchPokemon equation.
      */
     catchRate?: number;
@@ -1468,34 +1589,29 @@ export interface IPokemon extends BattleMovr.IActor {
     criticalHitProbability?: boolean;
 
     /**
-     * Whether the Pokemon was traded from another trainer.
+     * The Pokemon's nickname.
      */
-    traded?: boolean;
+    nickname: string[];
 
     /**
      * The level the Pokemon was before enabling the Level 100 mod.
      */
     previousLevel?: number;
-}
-
-/**
- * A Pokemon's level of experience.
- */
-export interface IExperience {
-    /**
-     * How much experience the Pokemon currently has.
-     */
-    current: number;
 
     /**
-     * The amount of experience required for the next level.
+     * Any current status, such as "Poison".
      */
-    next: number;
+    status: string;
 
     /**
-     * How much experience until the next level, as next - current.
+     * Whether the Pokemon was traded from another trainer.
      */
-    remaining: number;
+    traded?: boolean;
+
+    /**
+     * What types this Pokemon is, such as "Water".
+     */
+    types: string[];
 }
 
 /**
@@ -2671,7 +2787,7 @@ export interface IBattleActionRoutineSettings extends IBattleRoutineSettings {
     /**
      * Which battler this animation applies to.
      */
-    battlerName?: string;
+    battlerName?: "player" | "opponent";
 
     /**
      * How much damage this will do, if applicable.
@@ -2694,14 +2810,14 @@ export interface IBattleLevelRoutineSettings extends IBattleRoutineSettings {
  */
 export interface IBattleAttackRoutineSettings extends IBattleRoutineSettings {
     /**
-     * The attacking battler's name, as "player" or "opponent".
+     * The attacking battler's name.
      */
-    attackerName?: string;
+    attackerName?: "player" | "opponent";
 
     /**
-     * The defending battler's name, as "player" or "opponent".
+     * The defending battler's name.
      */
-    defenderName?: string;
+    defenderName?: "player" | "opponent";
 }
 
 /**

--- a/src/Menus.ts
+++ b/src/Menus.ts
@@ -425,7 +425,8 @@ export class Menus<TEightBittr extends FullScreenPokemon> extends EightBittr.Com
 
         this.EightBitter.MenuGrapher.addMenuDialog(
             "PokemonMenuStatsExperienceFrom",
-            this.EightBitter.utilities.makeDigit(pokemon.experience.remaining, 3, "\t"));
+            this.EightBitter.utilities.makeDigit(
+                (pokemon.experience.next - pokemon.experience.current), 3, "\t"));
 
         this.EightBitter.MenuGrapher.addMenuDialog(
             "PokemonMenuStatsExperienceNext",
@@ -499,16 +500,16 @@ export class Menus<TEightBittr extends FullScreenPokemon> extends EightBittr.Com
      * @param settings   Custom attributes to apply to the menu.
      */
     public openPokemonMenu(settings: MenuGraphr.IMenuSchema): void {
-        let listings: BattleMovr.IActor[] = this.EightBitter.ItemsHolder.getItem("PokemonInParty");
+        const listings: IPokemon[] = this.EightBitter.ItemsHolder.getItem("PokemonInParty");
         if (!listings || !listings.length) {
             return;
         }
 
-        let references: any = this.EightBitter.MathDecider.getConstant("pokemon");
+        const references: any = this.EightBitter.MathDecider.getConstant("pokemon");
 
         this.EightBitter.MenuGrapher.createMenu("Pokemon", settings);
         this.EightBitter.MenuGrapher.addMenuList("Pokemon", {
-            options: listings.map((listing: BattleMovr.IActor, i: number): any => {
+            options: listings.map((listing: IPokemon, i: number): any => {
                 const sprite: string = references[listing.title.join("")].sprite + "Pokemon";
                 const barWidth: number = 25;
                 const health: number = this.EightBitter.MathDecider.compute(
@@ -576,7 +577,7 @@ export class Menus<TEightBittr extends FullScreenPokemon> extends EightBittr.Com
                         }],
                     textsFloating: [
                         {
-                            text: String(listing.level),
+                            text: listing.level.toString(),
                             x: 44.25,
                             y: 0
                         },

--- a/src/Settings/Battles.ts
+++ b/src/Settings/Battles.ts
@@ -6,17 +6,11 @@ export function GenerateBattlesSettings(): IBattleMovrCustoms {
     "use strict";
 
     return {
-        battleMenuName: "Battle",
-        battleOptionNames: {
-            moves: "FIGHT",
-            items: "ITEM",
-            actors: ["Poke", "Mon"],
-            exit: "RUN"
-        },
         menuNames: {
-            moves: "BattleFightList",
-            items: "Items",
-            actors: "Pokemon"
+            battle: "Battle",
+            battleDisplayInitial: "BattleDisplayInitial",
+            generalText: "GeneralText",
+            player: "BattleOptions"
         },
         backgroundType: "DirtWhite",
         defaults: {

--- a/src/Settings/Math.ts
+++ b/src/Settings/Math.ts
@@ -5,8 +5,8 @@ import { Unitsize } from "../Constants";
 import { Cycling } from "../Cycling";
 import { Fishing } from "../Fishing";
 import {
-    IBattleBall, IBattleInfo, IBattleModification, IBattleThingInfo,
-    ICharacter, IExperience, IGrass, IHMMoveSchema,
+    IBattleBall, IBattleInfo, IBattleModification, IBattler,
+    ICharacter, IGrass, IHMMoveSchema,
     IMathConstants, IMathDecidrCustoms, IMathEquations, IMovePossibility,
     IMoveSchema, IPokemon, IPokemonListing, IPokemonMoveListing, IRod
 } from "../IFullScreenPokemon";
@@ -72,8 +72,9 @@ export function GenerateMathSettings(): IMathDecidrCustoms {
                 for (let i: number = Math.max(end - 4, 0); i < end; i += 1) {
                     move = possibilities[i];
                     newMove = {
-                        "title": move.move,
-                        "remaining": constants.moves[move.move].PP
+                        title: move.move,
+                        remaining: constants.moves[move.move].PP,
+                        uses: constants.moves[move.move].PP
                     };
 
                     output.push(newMove);
@@ -111,14 +112,10 @@ export function GenerateMathSettings(): IMathDecidrCustoms {
                     "Special": 0
                 };
             },
-            "newPokemonExperience": function (constants: IMathConstants, equations: IMathEquations, title: string[], level: number): IExperience {
-                const current: number = this.compute("experienceStarting", title, level);
-                const next: number = this.compute("experienceStarting", title, level + 1);
-
+            "newPokemonExperience": function (constants: IMathConstants, equations: IMathEquations, title: string[], level: number): BattleMovr.IActorExperience {
                 return {
-                    "current": current,
-                    "next": next,
-                    "remaining": next - current
+                    current: this.compute("experienceStarting", title, level),
+                    next: this.compute("experienceStarting", title, level + 1)
                 };
             },
             // http://bulbapedia.bulbagarden.net/wiki/Individual_values
@@ -240,7 +237,7 @@ export function GenerateMathSettings(): IMathDecidrCustoms {
             },
             // http://wiki.pokemonspeedruns.com/index.php/Pok%C3%A9mon_Red/Blue/Yellow_Trainer_AI
             // TO DO: Also filter for moves with > 0 remaining remaining...
-            "opponentMove": function (constants: IMathConstants, equations: IMathEquations, player: IBattleThingInfo, opponent: IBattleThingInfo): string {
+            "opponentMove": function (constants: IMathConstants, equations: IMathEquations, player: IBattler, opponent: IBattler): string {
                 let possibilities: IMovePossibility[] = opponent.selectedActor.moves.map(
                     (move: BattleMovr.IMove): IMovePossibility => {
                         return {
@@ -392,7 +389,7 @@ export function GenerateMathSettings(): IMathDecidrCustoms {
             // http://bulbapedia.bulbagarden.net/wiki/Priority
             // TO DO: Account for items, switching, etc.
             // TO DO: Factor in spec differences from paralyze, etc.
-            "playerMovesFirst": function (constants: IMathConstants, equations: IMathEquations, player: IBattleThingInfo, choicePlayer: string, opponent: IBattleThingInfo, choiceOpponent: string): boolean {
+            "playerMovesFirst": function (constants: IMathConstants, equations: IMathEquations, player: IBattler, choicePlayer: string, opponent: IBattler, choiceOpponent: string): boolean {
                 const movePlayer: IMoveSchema = constants.moves[choicePlayer];
                 const moveOpponent: IMoveSchema = constants.moves[choiceOpponent];
 
@@ -495,7 +492,7 @@ export function GenerateMathSettings(): IMathDecidrCustoms {
                 }
             },
             // http://bulbapedia.bulbagarden.net/wiki/Experience#Gain_formula
-            "experienceGained": function (constants: IMathConstants, equations: IMathEquations, player: IBattleThingInfo, opponent: IBattleThingInfo): number {
+            "experienceGained": function (constants: IMathConstants, equations: IMathEquations, player: IBattler, opponent: IBattler): number {
                 // a is equal to 1 if the fainted Pokemon is wild, or 1.5 if the fainted Pokemon is owned by a Trainer
                 let a: number = opponent.category === "Trainer" ? 1.5 : 1;
 

--- a/src/Settings/Mods.ts
+++ b/src/Settings/Mods.ts
@@ -2,7 +2,7 @@
 /// <reference path="../../typings/ModAttachr.d.ts" />
 
 import {
-    IArea, IBattleInfo, IBattleThingInfo, ICharacter, IEnemy, IGrass,
+    IArea, IBattleInfo, IBattler, ICharacter, IEnemy, IGrass,
     IItemSchema, IMap, IPokemon
 } from "../IFullScreenPokemon";
 
@@ -89,7 +89,7 @@ export function GenerateModsSettings(): GameStartr.IModAttachrCustoms {
                             });
                     },
                     onBattleStart: function (mod: ModAttachr.IMod, eventName: string, battleInfo: IBattleInfo): void {
-                        let opponent: IBattleThingInfo = battleInfo.opponent;
+                        let opponent: IBattler = battleInfo.battlers.opponent;
 
                         opponent.sprite = "BugCatcherFront";
                         opponent.name = "YOUNGSTER JOEY".split("");
@@ -184,7 +184,7 @@ export function GenerateModsSettings(): GameStartr.IModAttachrCustoms {
                         const grass: IGrass = this.player.grass;
                         const grassMap: IMap = grass ? this.AreaSpawner.getMap(grass.mapName) as IMap : undefined;
                         const grassArea: IArea = grassMap ? grassMap.areas[grass.areaName] as IArea : undefined;
-                        const opponent: String = settings.opponent.category;
+                        const opponent: String = settings.battlers.opponent.category;
 
                         if (!grassArea || opponent !== "Wild") {
                             return;
@@ -225,10 +225,10 @@ export function GenerateModsSettings(): GameStartr.IModAttachrCustoms {
                     onFaint: function (
                         mod: ModAttachr.IMod,
                         eventName: string,
-                        thing: BattleMovr.IActor,
+                        thing: IPokemon,
                         actors: IPokemon[]): void {
-                        const partyPokemon: BattleMovr.IActor[] = this.ItemsHolder.getItem("PokemonInParty");
-                        const pcPokemon: BattleMovr.IActor[] = this.ItemsHolder.getItem("PokemonInPC");
+                        const partyPokemon: IPokemon[] = this.ItemsHolder.getItem("PokemonInParty");
+                        const pcPokemon: IPokemon[] = this.ItemsHolder.getItem("PokemonInPC");
 
                         actors.splice(actors.indexOf(thing), 1);
                         partyPokemon.splice(partyPokemon.indexOf(thing), 1);
@@ -296,8 +296,8 @@ export function GenerateModsSettings(): GameStartr.IModAttachrCustoms {
                      * @param battleInfo   Settings for the current battle.
                      */
                     onBattleReady: function (mod: ModAttachr.IModAttachr, eventName: string, battleInfo: IBattleInfo): void {
-                        const opponent: IBattleThingInfo = battleInfo.opponent;
-                        const player: IBattleThingInfo = battleInfo.player;
+                        const opponent: IBattler = battleInfo.battlers.opponent;
+                        const player: IBattler = battleInfo.battlers.player;
                         const statistics: string[] = this.MathDecider.getConstant("statisticNames");
                         const enemyPokemonAvg: number = this.MathDecider.compute("averageLevel", opponent.actors);
                         const playerPokemonAvg: number = this.MathDecider.compute("averageLevel", player.actors);

--- a/typings/BattleMovr.d.ts
+++ b/typings/BattleMovr.d.ts
@@ -31,256 +31,459 @@ declare namespace BattleMovr {
      */
     class BattleMovr implements IBattleMovr {
         /**
-         * The IGameStartr providing Thing and actor informtaion.
+         * The IGameStartr providing Thing and actor information.
          */
-        private GameStarter;
+        protected GameStarter: IGameStartr;
         /**
-         *
+         * Names of known MenuGraphr menus.
          */
-        private things;
+        protected menuNames: IMenuNames;
         /**
-         * The type of Thing to create and use as the background.
+         * Option menus the player may select during battle.
+         */
+        protected battleOptions: IBattleOption[];
+        /**
+         * Default settings for running battles.
+         */
+        protected defaults: IBattleInfoDefaults;
+        /**
+         * Default positions of in-battle Things.
+         */
+        protected positions: IPositions;
+        /**
+         * Current settings for a running battle.
+         */
+        protected battleInfo: IBattleInfo;
+        /**
+         * All in-battle Things.
+         */
+        protected things: IThingsContainer;
+        /**
+         * The type of Thing to create and use as a background.
          */
         private backgroundType;
         /**
-         *
+         * The created Thing used as a background.
          */
         private backgroundThing;
         /**
-         *
-         */
-        private battleMenuName;
-        /**
-         *
-         */
-        private battleOptionNames;
-        /**
-         *
-         */
-        private menuNames;
-        /**
-         *
-         */
-        private battleInfo;
-        /**
-         *
+         * Whether a battle is currently happening.
          */
         private inBattle;
         /**
+         * Initializes a new instance of the BattleMovr class.
          *
-         */
-        private defaults;
-        /**
-         *
-         */
-        private positions;
-        /**
-         *
-         */
-        private openItemsMenuCallback;
-        /**
-         *
-         */
-        private openActorsMenuCallback;
-        /**
-         * @param {IBattleMovrSettings} settings
+         * @param settings   Settings to be used for initialization.
          */
         constructor(settings: IBattleMovrSettings);
         /**
-         *
+         * @returns The IGameStartr providing Thing and actor information.
          */
         getGameStarter(): IGameStartr;
         /**
-         *
+         * @returns Names of known MenuGraphr menus.
+         */
+        getMenuNames(): IMenuNames;
+        /**
+         * @returns Default settings for running battles.
+         */
+        getDefaults(): IBattleInfoDefaults;
+        /**
+         * @returns All in-battle Things.
          */
         getThings(): IThingsContainer;
         /**
-         *
+         * @param name   A name of an in-battle Thing.
+         * @returns The named in-battle Thing.
          */
-        getThing(name: string): IThing;
+        getThing(name: string): GameStartr.IThing;
         /**
-         *
+         * @returns Current settings for a running battle.
          */
         getBattleInfo(): IBattleInfo;
         /**
-         *
-         */
-        getBackgroundType(): string;
-        /**
-         *
-         */
-        getBackgroundThing(): IThing;
-        /**
-         *
+         * @returns Whether a battle is currently happening.
          */
         getInBattle(): boolean;
         /**
-         *
+         * @returns The type of Thing to create and use as a background.
          */
-        startBattle(settings: IBattleSettings): void;
+        getBackgroundType(): string;
         /**
+         * @returns The created Thing used as a background.
+         */
+        getBackgroundThing(): GameStartr.IThing;
+        /**
+         * Starts a battle.
          *
+         * @param settings   Settings for running the battle.
+         */
+        startBattle(settings: IBattleInfo): void;
+        /**
+         * Closes any current battle.
+         *
+         * @param callback   A callback to run after the battle is closed.
+         * @remarks The callback will run after deleting menus but before the next cutscene.
          */
         closeBattle(callback?: () => void): void;
         /**
-         *
+         * Shows the player menu.
          */
         showPlayerMenu(): void;
         /**
+         * Creates and displays an in-battle Thing.
          *
+         * @param name   The storage name of the Thing.
+         * @param title   The Thing's in-game type.
+         * @param settings   Any additional settings to create the Thing.
+         * @returns The created Thing.
          */
-        setThing(name: string, title: string, settings?: any): IThing;
+        setThing(name: string, title: string, settings?: any): GameStartr.IThing;
         /**
+         * Starts a round of battle with a player's move.
          *
-         */
-        openMovesMenu(): void;
-        /**
-         *
-         */
-        openItemsMenu(): void;
-        /**
-         *
-         */
-        openActorsMenu(callback: (settings: any) => void): void;
-        /**
-         *
+         * @param choisePlayer   The player's move choice.
          */
         playMove(choicePlayer: string): void;
         /**
+         * Switches a battler's actor.
          *
+         * @param battlerName   The name of the battler.
          */
-        switchActor(battlerName: string, i: number): void;
+        switchActor(battlerName: "player" | "opponent", i: number): void;
         /**
+         * Creates the battle background.
          *
+         * @param type   A type of background, if not the default.
          */
-        startBattleExit(): void;
+        createBackground(type?: string): void;
         /**
-         *
-         */
-        createBackground(): void;
-        /**
-         *
+         * Deletes the battle background.
          */
         deleteBackground(): void;
     }
+    /**
+     * Extended IGameStartr with menus.
+     */
     interface IGameStartr extends GameStartr.GameStartr {
+        /**
+         * In-game menu and dialog creation and management for GameStartr.
+         */
         MenuGrapher: MenuGraphr.IMenuGraphr;
     }
+    /**
+     * Description of a menu available during battle.
+     */
+    interface IBattleOption {
+        /**
+         * A callback that opens the menu.
+         */
+        callback: () => void;
+        /**
+         * Text displayed in the options menu.
+         */
+        text: MenuGraphr.IMenuDialogRaw;
+    }
+    /**
+     * Names of known MenuGraphr menus.
+     */
+    interface IMenuNames {
+        /**
+         * The primary backdrop battle menu.
+         */
+        battle: string;
+        /**
+         * The initial display when a battle starts.
+         */
+        battleDisplayInitial: string;
+        /**
+         * The player's options menu.
+         */
+        player: string;
+        /**
+         * General dialog text container.
+         */
+        generalText: string;
+    }
+    /**
+     * Positions of in-battle Things, keyed by name.
+     */
+    interface IPositions {
+        [i: string]: IPosition;
+    }
+    /**
+     * Position of an in-battle Thing.
+     */
     interface IPosition {
+        /**
+         * The Thing's left.
+         */
         left?: number;
+        /**
+         * The Thing's top.
+         */
         top?: number;
     }
+    /**
+     * A container for all in-battle Things.
+     */
     interface IThingsContainer {
-        menu?: IThing;
-        [i: string]: IThing;
+        /**
+         * Any initial battle display menu.
+         */
+        menu?: GameStartr.IThing;
+        [i: string]: GameStartr.IThing;
     }
-    interface IThing extends GameStartr.IThing {
-        groupType: string;
-    }
-    interface IMenu extends IThing {
-    }
-    interface IBattleSettings {
-        nextCutscene: string;
-        nextCutsceneSettings: string;
-    }
-    interface IBattleInfo {
-        exitDialog?: string;
-        items?: any;
-        nextCutscene?: string;
-        nextCutsceneSettings?: any;
-        nextRoutine?: string;
-        nextRoutineSettings?: any;
-        opponent?: IBattleThingInfo;
-        player?: IBattleThingInfo;
-    }
+    /**
+     * Default settings for running a battle.
+     */
     interface IBattleInfoDefaults {
-        exitDialog: string;
+        /**
+         * A dialog to display after the battle.
+         */
+        exitDialog?: MenuGraphr.IMenuDialogRaw;
+        /**
+         * A next cutscene to play after the battle.
+         */
+        nextCutscene?: string;
+        /**
+         * Any settings for the next cutscene.
+         */
+        nextCutsceneSettings?: ScenePlayr.ICutsceneSettings;
+        /**
+         * A next routine to play in a next cutscene.
+         */
+        nextRoutine?: string;
+        /**
+         * Any settings for the next cutscene's routine.
+         */
+        nextRoutineSettings?: any;
+        [i: string]: any;
     }
-    interface IBattleThingInfo {
-        actors: IActor[];
+    /**
+     * Settings for running a battle.
+     */
+    interface IBattleInfo extends IBattleInfoDefaults {
+        /**
+         * The players controlling battling actors.
+         */
+        battlers: IBattlers;
+    }
+    /**
+     * In-battle players controlling battling actors.
+     */
+    interface IBattlers {
+        /**
+         * The opponent battler's information.
+         */
+        opponent?: IBattler;
+        /**
+         * The player's battle information.
+         */
+        player?: IBattler;
+        [i: string]: IBattler;
+    }
+    /**
+     * An in-battle player.
+     */
+    interface IBattler {
+        /**
+         * Actors that may be sent out to battle.
+         */
+        actors?: IActor[];
+        /**
+         * The game-specific category of fighter, such as "Trainer" or "Wild".
+         */
         category: string;
+        /**
+         * Whether the player has actors, rather than fighting alone.
+         */
         hasActors?: boolean;
+        /**
+         * The name of the player.
+         */
         name: string[];
+        /**
+         * Which actor is currently selected to battle, if any.
+         */
         selectedActor?: IActor;
+        /**
+         * The index of the currently selected actor, if any.
+         */
         selectedIndex?: number;
+        /**
+         * A sprite name to send out to battle.
+         */
         sprite: string;
     }
+    /**
+     * An actor that may be sent out in battle.
+     */
     interface IActor {
-        Attack: number;
-        AttackNormal: number;
-        Defense: number;
-        DefenseNormal: number;
-        EV: {
-            Attack: number;
-            Defense: number;
-            Special: number;
-            Speed: number;
-        };
-        HP: number;
-        HPNormal: number;
-        IV: {
-            Attack: number;
-            Defense: number;
-            HP: number;
-            Special: number;
-            Speed: number;
-        };
-        Special: number;
-        SpecialNormal: number;
-        Speed: number;
-        SpeedNormal: number;
+        /**
+         * Experience points for leveling up.
+         */
         experience: IActorExperience;
+        /**
+         * The actor's current level.
+         */
         level: number;
+        /**
+         * Moves the actor knows.
+         */
         moves: IMove[];
-        nickname: string[];
-        status: string;
+        /**
+         * The primary title of the actor.
+         */
         title: string[];
-        types: string[];
     }
+    /**
+     * An actor's experience points for leveling up.
+     */
     interface IActorExperience {
+        /**
+         * Current amount of experience points.
+         */
         current: number;
+        /**
+         * How many experience points are needed for the next level.
+         */
         next: number;
-        remaining: number;
     }
+    /**
+     * An actor's knowledge of a battle move.
+     */
     interface IMove {
+        /**
+         * The name of the battle move.
+         */
         title: string;
+        /**
+         * How many uses are remaining.
+         */
         remaining: number;
+        /**
+         * How many total uses of this move are allowed.
+         */
+        uses: number;
     }
+    /**
+     * Settings to initialize a new IBattleMovr instance.
+     */
     interface IBattleMovrSettings {
+        /**
+         * The IGameStartr providing Thing and actor information.
+         */
         GameStarter: IGameStartr;
-        battleMenuName: string;
-        battleOptionNames: string;
-        menuNames: string;
-        openItemsMenuCallback: (settings: any) => void;
-        openActorsMenuCallback: (settings: any) => void;
-        defaults?: any;
+        /**
+         *
+         */
+        battleOptions: IBattleOption[];
+        /**
+         *
+         */
+        menuNames: IMenuNames;
+        /**
+         * Default settings for running battles.
+         */
+        defaults?: IBattleInfoDefaults;
+        /**
+         *
+         */
         backgroundType?: string;
-        positions?: any;
+        /**
+         *
+         */
+        positions?: IPositions;
     }
     /**
      * A driver for RPG-like battles between two collections of actors.
      */
     interface IBattleMovr {
+        /**
+         * @returns The IGameStartr providing Thing and actor information.
+         */
         getGameStarter(): IGameStartr;
-        getThings(): {
-            [i: string]: IThing;
-        };
-        getThing(name: string): IThing;
+        /**
+         * @returns Names of known MenuGraphr menus.
+         */
+        getMenuNames(): IMenuNames;
+        /**
+         * @returns Default settings for running battles.
+         */
+        getDefaults(): IBattleInfoDefaults;
+        /**
+         * @returns All in-battle Things.
+         */
+        getThings(): IThingsContainer;
+        /**
+         * @param name   A name of an in-battle Thing.
+         * @returns The named in-battle Thing.
+         */
+        getThing(name: string): GameStartr.IThing;
+        /**
+         * @returns Current settings for a running battle.
+         */
         getBattleInfo(): IBattleInfo;
-        getBackgroundType(): string;
-        getBackgroundThing(): IThing;
+        /**
+         * @returns Whether a battle is currently happening.
+         */
         getInBattle(): boolean;
-        startBattle(settings: IBattleSettings): void;
+        /**
+         * @returns The type of Thing to create and use as a background.
+         */
+        getBackgroundType(): string;
+        /**
+         * @returns The created Thing used as a background.
+         */
+        getBackgroundThing(): GameStartr.IThing;
+        /**
+         * Starts a battle.
+         *
+         * @param settings   Settings for running the battle.
+         */
+        startBattle(settings: IBattleInfo): void;
+        /**
+         * Closes any current battle.
+         *
+         * @param callback   A callback to run after the battle is closed.
+         * @remarks The callback will run after deleting menus but before the next cutscene.
+         */
         closeBattle(callback?: () => void): void;
+        /**
+         * Shows the player menu.
+         */
         showPlayerMenu(): void;
-        setThing(name: string, title: string, settings?: any): IThing;
-        openMovesMenu(): void;
-        openItemsMenu(): void;
-        openActorsMenu(callback: (settings: any) => void): void;
+        /**
+         * Creates and displays an in-battle Thing.
+         *
+         * @param name   The storage name of the Thing.
+         * @param title   The Thing's in-game type.
+         * @param settings   Any additional settings to create the Thing.
+         * @returns The created Thing.
+         */
+        setThing(name: string, title: string, settings?: any): GameStartr.IThing;
+        /**
+         * Starts a round of battle with a player's move.
+         *
+         * @param choisePlayer   The player's move choice.
+         */
         playMove(choicePlayer: string): void;
-        switchActor(battlerName: string, i: number): void;
-        startBattleExit(): void;
-        createBackground(): void;
+        /**
+         * Switches a battler's actor.
+         *
+         * @param battlerName   The name of the battler.
+         */
+        switchActor(battlerName: "player" | "opponent", i: number): void;
+        /**
+         * Creates the battle background.
+         *
+         * @param type   A type of background, if not the default.
+         */
+        createBackground(type?: string): void;
+        /**
+         * Deletes the battle background.
+         */
         deleteBackground(): void;
     }
 }


### PR DESCRIPTION
The biggest change is that `battleInfo` now has a `battlers` section for
the player and opponent. This removes the need for some of those ugly
`any` casts.

Starts on #126.