### PR TITLE
Brought in gulp-shenanigans with src tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,8 @@
 lib/**
 src/**/*.css
 src/**/*.js*
-~src/main.js
+test/main.ts
 test/**/*.js
-test/index.css
 test/index.html
 test/utils/**
 !test/utils/mocks.ts

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "js-beautify": "^1.6.3"
   },
   "devDependencies": {
-    "gulp-shenanigans": "^0.5.14",
+    "gulp-shenanigans": "^0.5.15",
     "@types/js-beautify": "0.0.27"
   }
 }

--- a/test/FullScreenPokemon/_.ts
+++ b/test/FullScreenPokemon/_.ts
@@ -1,7 +1,10 @@
 /// <reference path="../../node_modules/@types/chai/index.d.ts" />
 /// <reference path="../../node_modules/@types/mocha/index.d.ts" />
-/// <reference path="../../lib/FullScreenPokemon.d.ts" />
 /// <reference path="../utils/MochaLoader.ts" />
-/// <reference path="../utils/mocks.ts" />
 
-mochaLoader.addTest("_", (): void => { });
+import { mocks } from "../utils/mocks";
+import { mochaLoader } from "../main";
+
+mochaLoader.it("_", (): void => {
+    chai.expect(() => mocks.mockFullScreenPokemon()).to.not.throw();
+});

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,9 +1,11 @@
 {
     "compilerOptions": {
-        "target": "es3",
-        "declaration": false
+        "declaration": false,
+        "module": "amd",
+        "target": "es3"
     },
     "files": [
+        "main.ts",
         "utils/mocks.ts",
         "utils/MochaLoader.ts",
         "FullScreenPokemon/_.ts"

--- a/test/utils/mocks.ts
+++ b/test/utils/mocks.ts
@@ -1,5 +1,10 @@
-/// <reference path="../../lib/FullScreenPokemon.d.ts" />
+import { FullScreenPokemon } from "../../src/FullScreenPokemon";
 
-const mocks = {
-    // ...
+export const mocks = {
+    mockFullScreenPokemon: (): FullScreenPokemon => {
+        return new FullScreenPokemon({
+            width: 400,
+            height: 400
+        })
+    }
 };


### PR DESCRIPTION
Tests will now run against the compiled files in `/src`, so there's no longer any need to wait for all of `dist` to happen.