### PR TITLE
Extend "Scaling Levels" mod to factor potential wild Pokemon levels

### DIFF
--- a/src/Settings/Math.ts
+++ b/src/Settings/Math.ts
@@ -35,15 +35,14 @@ export function GenerateMathSettings(): IMathDecidrCustoms {
                     if (wildPokemon.level) {
                         average += wildPokemon.level * wildPokemon.rate;
                         continue;
-                    } else {
-                        let levelAverage: number = 0;
-
-                        for (const level of wildPokemon.levels) {
-                            levelAverage += level * (1 / wildPokemon.levels.length);
-                        }
-
-                        average += levelAverage * wildPokemon.rate;
                     }
+                    let levelAverage: number = 0;
+
+                    for (const level of wildPokemon.levels) {
+                        levelAverage += level * (1 / wildPokemon.levels.length);
+                    }
+
+                    average += levelAverage * wildPokemon.rate;
                 }
 
                 return Math.round(average);

--- a/src/Settings/Math.ts
+++ b/src/Settings/Math.ts
@@ -34,6 +34,7 @@ export function GenerateMathSettings(): IMathDecidrCustoms {
                 for (const wildPokemon of options) {
                     if (wildPokemon.level) {
                         average += wildPokemon.level * wildPokemon.rate;
+                        continue;
                     } else {
                         let levelAverage: number = 0;
 

--- a/src/Settings/Math.ts
+++ b/src/Settings/Math.ts
@@ -8,7 +8,7 @@ import {
     IBattleBall, IBattleInfo, IBattleModification, IBattler,
     ICharacter, IGrass, IHMMoveSchema,
     IMathConstants, IMathDecidrCustoms, IMathEquations, IMovePossibility,
-    IMoveSchema, IPokemon, IPokemonListing, IPokemonMoveListing, IRod
+    IMoveSchema, IPokemon, IPokemonListing, IPokemonMoveListing, IRod, IWildPokemonSchema
 } from "../IFullScreenPokemon";
 
 /* tslint:disable:max-line-length */
@@ -27,6 +27,25 @@ export function GenerateMathSettings(): IMathDecidrCustoms {
                 }
 
                 return Math.round(average / actors.length);
+            },
+            "averageLevelWildPokemon": function (constants: IMathConstants, equations: IMathEquations, options: IWildPokemonSchema[]): number {
+                let average: number = 0;
+
+                for (const wildPokemon of options) {
+                    if (wildPokemon.level) {
+                        average += wildPokemon.level * wildPokemon.rate;
+                    } else {
+                        let levelAverage: number = 0;
+
+                        for (const level of wildPokemon.levels) {
+                            levelAverage += level * (1 / wildPokemon.levels.length);
+                        }
+
+                        average += levelAverage * wildPokemon.rate;
+                    }
+                }
+
+                return Math.round(average);
             },
             "speedCycling": function (constants: IMathConstants, equations: IMathEquations, thing: ICharacter): number {
                 return thing.speed * 2;

--- a/src/Settings/Mods.ts
+++ b/src/Settings/Mods.ts
@@ -3,7 +3,7 @@
 
 import {
     IArea, IBattleInfo, IBattler, ICharacter, IEnemy, IGrass,
-    IItemSchema, IMap, IPokemon
+    IItemSchema, IMap, IPokemon, IWildPokemonSchema
 } from "../IFullScreenPokemon";
 
 const onModEnableKey: string = "onModEnable";
@@ -298,8 +298,12 @@ export function GenerateModsSettings(): GameStartr.IModAttachrCustoms {
                     onBattleReady: function (mod: ModAttachr.IModAttachr, eventName: string, battleInfo: IBattleInfo): void {
                         const opponent: IBattler = battleInfo.battlers.opponent;
                         const player: IBattler = battleInfo.battlers.player;
+                        const isWildBattle: boolean = opponent.name === opponent.actors[0].nickname;
+                        const wildPokemonOptions: IWildPokemonSchema[] = this.AreaSpawner.getArea().wildPokemon.grass;
                         const statistics: string[] = this.MathDecider.getConstant("statisticNames");
-                        const enemyPokemonAvg: number = this.MathDecider.compute("averageLevel", opponent.actors);
+                        const enemyPokemonAvg: number = isWildBattle ?
+                            this.MathDecider.compute("averageLevelWildPokemon", wildPokemonOptions) :
+                            this.MathDecider.compute("averageLevel", opponent.actors);
                         const playerPokemonAvg: number = this.MathDecider.compute("averageLevel", player.actors);
 
                         for (const actor of opponent.actors) {


### PR DESCRIPTION
Fixes Issue #263 
## What was done
* First decided if it was a wild pokemon battle or not. Done by checking the opponent's name with the name of its first party pokemon. Since there is no trainer for a wild battle the wild pokemon's name is used instead in the battle options. It will also have a list of party pokemon, containing only itself.
* Next I wrote a new function to compute the average level for an area as opposed to my previous function of computing the average level for a party of pokemon. This gets the current area and uses the spawn rate to to do a percentage-based average (if there is a pokemon with multiple levels at the same rate, I take the average of these levels).
* The original logic then continues with this new average level
