### PR TITLE
Added mod for "Mobile PokeCenter'

### DIFF
--- a/src/Settings/Mods.ts
+++ b/src/Settings/Mods.ts
@@ -329,10 +329,18 @@ export function GenerateModsSettings(): GameStartr.IModAttachrCustoms {
                             this.battles.healPokemon(pokemon);
                         }
 
-                        this.menus.displayMessage("Your party has been fully healed!");
+                        this.MenuGrapher.createMenu("GeneralText", {
+                            deleteOnFinish: true,
+                            onMenuDelete: () => onChange(false)
+                        });
+                        this.MenuGrapher.addMenuDialog(
+                            "GeneralText",
+                            [
+                                "Your party has been fully healed!"
+                            ]
+                        );
+                        this.MenuGrapher.setActiveMenu("GeneralText");
                         this.ModAttacher.toggleMod("Mobile PokeCenter");
-                        // Call onChange with true because UserWrappr flips it right after.
-                        onChange(true);
                     },
                     onModDisable: function (mod: ModAttachr.IMod): void {
                         return;

--- a/src/Settings/Mods.ts
+++ b/src/Settings/Mods.ts
@@ -331,14 +331,13 @@ export function GenerateModsSettings(): GameStartr.IModAttachrCustoms {
 
                         this.MenuGrapher.createMenu("GeneralText", {
                             deleteOnFinish: true,
-                            onMenuDelete: () => onChange(false)
+                            onMenuDelete: (): void => onChange(false)
                         });
                         this.MenuGrapher.addMenuDialog(
                             "GeneralText",
                             [
                                 "Your party has been fully healed!"
-                            ]
-                        );
+                            ]);
                         this.MenuGrapher.setActiveMenu("GeneralText");
                         this.ModAttacher.toggleMod("Mobile PokeCenter");
                     },

--- a/src/Settings/Mods.ts
+++ b/src/Settings/Mods.ts
@@ -316,6 +316,28 @@ export function GenerateModsSettings(): GameStartr.IModAttachrCustoms {
                         }
                     }
                 }
+            },
+            {
+                name: "Mobile PokeCenter",
+                enabled: false,
+                events: {
+                    onModEnable: function (mod: ModAttachr.IMod, eventName: string, args: any[]): void {
+                        const party: IPokemon[] = this.ItemsHolder.getItem("PokemonInParty");
+                        const onChange: (enabled: boolean) => void = args[1][0];
+
+                        for (const pokemon of party) {
+                            this.battles.healPokemon(pokemon);
+                        }
+
+                        this.menus.displayMessage("Your party has been fully healed!");
+                        this.ModAttacher.toggleMod("Mobile PokeCenter");
+                        // Call onChange with true because UserWrappr flips it right after.
+                        onChange(true);
+                    },
+                    onModDisable: function (mod: ModAttachr.IMod): void {
+                        return;
+                    }
+                }
             }
         ]
     };

--- a/src/Settings/Ui.ts
+++ b/src/Settings/Ui.ts
@@ -191,12 +191,13 @@ export function GenerateUISettings(): IUserWrapprCustoms {
 
                     return output;
                 },
-                callback: (FSP: FullScreenPokemon, schema: UserWrappr.ISchema, button: HTMLElement): void => {
+                callback: (FSP: FullScreenPokemon, schema: UserWrappr.ISchema, button: HTMLElement,
+                            onChange: (enabled: boolean) => void): void => {
                     const name: string = button.textContent;
                     const key: string = button.getAttribute("localStorageKey");
                     const mod: ModAttachr.IMod = FSP.ModAttacher.getMod(name);
 
-                    FSP.ModAttacher.toggleMod(name);
+                    FSP.ModAttacher.toggleMod(name, onChange);
                     FSP.ItemsHolder.setItem(key, mod.enabled);
                     FSP.ItemsHolder.saveItem(key);
                 }


### PR DESCRIPTION
Fixes #241 

## What was done
It was as simple as calling `battles.healPokemon` on all the current party pokemon. There is also a message box letting the player know his/her party has been healed. 
I was able to fix the problem where the option button for the mod wouldn't disable in the UI. This was done by having UserWrappr pass a callback called `onChange` to `toggleMod`, which passes it to `enableMod`, and the `onModEnable` of "Mobile PokeCenter" uses it from there. What `onChange` does is allow Mods to change the `enabled` state and className of the "Mobile PokeCenter" option button.