### PR TITLE
Implemented evolution functionality for when Pokemon level up, and extended that functionality to "Scaling Levels" to evolve enemy pokemon

### DIFF
--- a/src/Settings/Mods.ts
+++ b/src/Settings/Mods.ts
@@ -309,9 +309,13 @@ export function GenerateModsSettings(): GameStartr.IModAttachrCustoms {
                         for (const actor of opponent.actors) {
                             actor.level += playerPokemonAvg - enemyPokemonAvg;
 
-                            for (const statistic of statistics) {
-                                (actor as any)[statistic] = (actor as any)[statistic + "Normal"] =
-                                    this.MathDecider.compute("pokemonStatistic", actor, statistic);
+                            if (this.utilities.shouldEvolve(actor)) {
+		                        this.utilities.evolvePokemon(actor);
+	                        } else {
+                                for (const statistic of statistics) {
+                                    (actor as any)[statistic] = (actor as any)[statistic + "Normal"] =
+                                        this.MathDecider.compute("pokemonStatistic", actor, statistic);
+                                }
                             }
                         }
                     }

--- a/src/Settings/Mods.ts
+++ b/src/Settings/Mods.ts
@@ -311,7 +311,7 @@ export function GenerateModsSettings(): GameStartr.IModAttachrCustoms {
 
                             if (this.utilities.shouldEvolve(actor)) {
 		                        this.utilities.evolvePokemon(actor);
-	                        } else {
+                            } else {
                                 for (const statistic of statistics) {
                                     (actor as any)[statistic] = (actor as any)[statistic + "Normal"] =
                                         this.MathDecider.compute("pokemonStatistic", actor, statistic);

--- a/src/Utilities.ts
+++ b/src/Utilities.ts
@@ -113,34 +113,28 @@ export class Utilities<TEightBittr extends FullScreenPokemon> extends GameStartr
      * @returns Whether the pokemon is able to evolve at current level.
      */
     public shouldEvolve(actor: IPokemon): boolean {
-        let t: string = actor.title.join();
+        let t: string = actor.title.join('');
         let p: any = this.EightBitter.MathDecider.getConstant("pokemon")[t];
         return actor.level === parseInt(p.evolvesVia.split(" ")[1], 10);
     }
 
     /**
-     * Function to evolve a pokemon and subsequently modify their stats
+     * Function to evolve a pokemon and subsequently modify their stats.
      * 
-     * @param actor   Pokemon to be evolved
-     * @returns   void
+     * @param actor   Pokemon to be evolved.
      */
     public evolvePokemon(actor: IPokemon): void {
-        let t: string = actor.title.join();
-        let p: any = this.EightBitter.MathDecider.getConstant("pokemon")[t];
-        let evolution: any = p.evolvesInto;
-        actor.title = evolution.toUppercase().split("");
+        let actorTitle: string = actor.title.join('');
+        let pokemon: any = this.EightBitter.MathDecider.getConstant("pokemon")[actorTitle];
+        let evolution: any = pokemon.evolvesInto;
+        actor.title = evolution.toUppercase().split('');
 
-        let evolInfo: any = this.EightBitter.MathDecider.getConstant("pokemon")[evolution.toUppercase()];
+        let evolutionInfo: any = this.EightBitter.MathDecider.getConstant("pokemon")[evolution.toUppercase()];
+        const statisticNames: string[] = this.EightBitter.MathDecider.getConstant("statisticNames");
 
-        actor.Attack = this.EightBitter.MathDecider.compute("pokemonStatistic", actor, evolInfo.Attack);
-        actor.AttackNormal = this.EightBitter.MathDecider.compute("pokemonStatistic", actor, evolInfo.Attack);
-        actor.Defense = this.EightBitter.MathDecider.compute("pokemonStatistic", actor, evolInfo.Defense);
-        actor.DefenseNormal = this.EightBitter.MathDecider.compute("pokemonStatistic", actor, evolInfo.Defense);
-        actor.HP = this.EightBitter.MathDecider.compute("pokemonStatistic", actor, evolInfo.HP);
-        actor.HPNormal = this.EightBitter.MathDecider.compute("pokemonStatistic", actor, evolInfo.HP);
-        actor.Special = this.EightBitter.MathDecider.compute("pokemonStatistic", actor, evolInfo.Special);
-        actor.SpecialNormal = this.EightBitter.MathDecider.compute("pokemonStatistic", actor, evolInfo.Special);
-        actor.Speed = this.EightBitter.MathDecider.compute("pokemonStatistic", actor, evolInfo.Speed);
-        actor.SpeedNormal = this.EightBitter.MathDecider.compute("pokemonStatistic", actor, evolInfo.Speed);
+        for (const statistic of statisticNames) {
+            (actor as any)[statistic] = this.EightBitter.MathDecider.compute("pokemonStatistic", pokemon, evolutionInfo.statistic);
+            (actor as any)[statistic + "Normal"] = pokemon[statistic];
+        }
     }
 }

--- a/src/Utilities.ts
+++ b/src/Utilities.ts
@@ -113,7 +113,7 @@ export class Utilities<TEightBittr extends FullScreenPokemon> extends GameStartr
      * @returns Whether the pokemon is able to evolve at current level.
      */
     public shouldEvolve(actor: IPokemon): boolean {
-        let t: string = actor.title.join('');
+        let t: string = actor.title.join("");
         let p: any = this.EightBitter.MathDecider.getConstant("pokemon")[t];
         return actor.level === parseInt(p.evolvesVia.split(" ")[1], 10);
     }
@@ -124,10 +124,10 @@ export class Utilities<TEightBittr extends FullScreenPokemon> extends GameStartr
      * @param actor   Pokemon to be evolved.
      */
     public evolvePokemon(actor: IPokemon): void {
-        let actorTitle: string = actor.title.join('');
+        let actorTitle: string = actor.title.join("");
         let pokemon: any = this.EightBitter.MathDecider.getConstant("pokemon")[actorTitle];
         let evolution: any = pokemon.evolvesInto;
-        actor.title = evolution.toUppercase().split('');
+        actor.title = evolution.toUppercase().split("");
 
         let evolutionInfo: any = this.EightBitter.MathDecider.getConstant("pokemon")[evolution.toUppercase()];
         const statisticNames: string[] = this.EightBitter.MathDecider.getConstant("statisticNames");

--- a/src/Utilities.ts
+++ b/src/Utilities.ts
@@ -105,4 +105,42 @@ export class Utilities<TEightBittr extends FullScreenPokemon> extends GameStartr
 
         return true;
     }
+
+    /**
+     * Function to check if a pokemon should evolve at current level.
+     * 
+     * @param actor   Pokemon to be checked for evolution.
+     * @returns Whether the pokemon is able to evolve at current level.
+     */
+    public shouldEvolve(actor: IPokemon): boolean {
+        let t: string = actor.title.join();
+        let p: any = this.EightBitter.MathDecider.getConstant("pokemon")[t];
+        return actor.level === parseInt(p.evolvesVia.split(" ")[1], 10);
+    }
+
+    /**
+     * Function to evolve a pokemon and subsequently modify their stats
+     * 
+     * @param actor   Pokemon to be evolved
+     * @returns   void
+     */
+    public evolvePokemon(actor: IPokemon): void {
+        let t: string = actor.title.join();
+        let p: any = this.EightBitter.MathDecider.getConstant("pokemon")[t];
+        let evolution: any = p.evolvesInto;
+        actor.title = evolution.toUppercase().split("");
+
+        let evolInfo: any = this.EightBitter.MathDecider.getConstant("pokemon")[evolution.toUppercase()];
+
+        actor.Attack = this.EightBitter.MathDecider.compute("pokemonStatistic", actor, evolInfo.Attack);
+        actor.AttackNormal = this.EightBitter.MathDecider.compute("pokemonStatistic", actor, evolInfo.Attack);
+        actor.Defense = this.EightBitter.MathDecider.compute("pokemonStatistic", actor, evolInfo.Defense);
+        actor.DefenseNormal = this.EightBitter.MathDecider.compute("pokemonStatistic", actor, evolInfo.Defense);
+        actor.HP = this.EightBitter.MathDecider.compute("pokemonStatistic", actor, evolInfo.HP);
+        actor.HPNormal = this.EightBitter.MathDecider.compute("pokemonStatistic", actor, evolInfo.HP);
+        actor.Special = this.EightBitter.MathDecider.compute("pokemonStatistic", actor, evolInfo.Special);
+        actor.SpecialNormal = this.EightBitter.MathDecider.compute("pokemonStatistic", actor, evolInfo.Special);
+        actor.Speed = this.EightBitter.MathDecider.compute("pokemonStatistic", actor, evolInfo.Speed);
+        actor.SpeedNormal = this.EightBitter.MathDecider.compute("pokemonStatistic", actor, evolInfo.Speed);
+    }
 }


### PR DESCRIPTION
Fixes #325 and #268 

Created the shouldEvolve function. Basically when a Pokemon evolves, I check their current level against the level in their JSON where they should evolve and check if they're equal. Looking back now, I should probably change it to check if it is greater than or equal to, instead of equal to, to account for trainers delaying the evolution of their Pokemon. That will have to be implemented alongside a function that stops an evolution.
Next I created evolvePokemon, which actually goes ahead and modifies the Pokemon attributes to account for the evolution: name, statistics, etc. 
I also went ahead and extended this to work alongside with "Scaling Levels". What happens is when the enemy Pokemon's levels are modified (scaled) to the current party's Pokemon, I will call the shouldEvolve function to check if these Pokemon are able to evolve, and call evolvePokemon if they are.
