### PR TITLE
Added AreaGates to help spawn across areas

### DIFF
--- a/src/Animations.ts
+++ b/src/Animations.ts
@@ -3,8 +3,8 @@
 import { Direction, DirectionAliases, DirectionClasses } from "./Constants";
 import { FullScreenPokemon } from "./FullScreenPokemon";
 import {
-    IArea, IAreaSpawner, ICharacter, IColorFadeSettings, IDetector, IDialog, IDialogOptions,
-    IEnemy, IGymDetector, IHMCharacter, IHMMoveSchema, IMap, IMenuTriggerer, IPlayer,
+    IArea, IAreaGate, IAreaSpawner, ICharacter, IColorFadeSettings, IDetector, IDialog,
+    IDialogOptions, IEnemy, IGymDetector, IHMCharacter, IHMMoveSchema, IMap, IMenuTriggerer, IPlayer,
     IPokemon, ISightDetector, IThemeDetector, IThing, ITransporter, ITransportSchema,
     IWalkingOnStop, IWalkingOnStopCommandFunction,
     IWildPokemonSchema
@@ -1669,6 +1669,37 @@ export class Animations<TEightBittr extends FullScreenPokemon> extends EightBitt
         area.spawnedBy = (this.EightBitter.AreaSpawner.getArea() as IArea).spawnedBy;
 
         this.EightBitter.maps.activateAreaSpawner(thing, area);
+    }
+
+    /**
+     * Activation callback for an AreaGate. The Player is marked to now spawn
+     * in the new Map and Area.
+     * 
+     * @param thing   A Character walking to other.
+     * @param other   An AreaGate potentially being triggered.
+     */
+    public activateAreaGate(thing: ICharacter, other: IAreaGate): void {
+        if (!thing.player || !thing.walking || thing.direction !== other.direction) {
+            return;
+        }
+
+        console.log("Now in map/area", other.map, other.area);
+        console.log("\t", other.areaOffsetX, other.areaOffsetY);
+
+        // Todo: figure out relative positioning
+        // let areaOffsetX: number = other.areaOffsetX;
+        // let areaOffsetY: number = other.areaOffsetY;
+
+        this.EightBitter.ItemsHolder.setItem("map", other.map);
+        this.EightBitter.ItemsHolder.setItem("area", other.area);
+        this.EightBitter.ItemsHolder.setItem("location", undefined);
+
+        other.active = false;
+        this.EightBitter.TimeHandler.addEvent(
+            (): void => {
+                other.active = true;
+            },
+            2);
     }
 
     /**

--- a/src/Animations.ts
+++ b/src/Animations.ts
@@ -1683,16 +1683,48 @@ export class Animations<TEightBittr extends FullScreenPokemon> extends EightBitt
             return;
         }
 
-        console.log("Now in map/area", other.map, other.area);
-        console.log("\t", other.areaOffsetX, other.areaOffsetY);
+        const area: IArea = this.EightBitter.AreaSpawner.getMap(other.map).areas[other.area] as IArea;
+        let areaOffsetX: number;
+        let areaOffsetY: number;
 
-        // Todo: figure out relative positioning
-        // let areaOffsetX: number = other.areaOffsetX;
-        // let areaOffsetY: number = other.areaOffsetY;
+        switch (thing.direction) {
+            case Direction.Top:
+                areaOffsetX = thing.left - other.left;
+                areaOffsetY = area.height * this.EightBitter.unitsize - thing.height;
+                break;
+
+            case Direction.Right:
+                areaOffsetX = 0;
+                areaOffsetY = thing.top - other.top;
+                break;
+
+            case Direction.Bottom:
+                areaOffsetX = thing.left - other.left;
+                areaOffsetY = 0;
+                break;
+
+            case Direction.Left:
+                areaOffsetX = area.width * this.EightBitter.unitsize - thing.width;
+                areaOffsetY = thing.top - other.top;
+                break;
+
+            default:
+                throw new Error(`Unknown direction: '${thing.direction}'.`);
+        }
+
+        const screenOffsetX: number = areaOffsetX - thing.left;
+        const screenOffsetY: number = areaOffsetY - thing.top;
+
+        this.EightBitter.MapScreener.top = screenOffsetY;
+        this.EightBitter.MapScreener.right = screenOffsetX + this.EightBitter.MapScreener.width;
+        this.EightBitter.MapScreener.bottom = screenOffsetY + this.EightBitter.MapScreener.height;
+        this.EightBitter.MapScreener.left = screenOffsetX;
 
         this.EightBitter.ItemsHolder.setItem("map", other.map);
         this.EightBitter.ItemsHolder.setItem("area", other.area);
         this.EightBitter.ItemsHolder.setItem("location", undefined);
+
+        this.EightBitter.StateHolder.setCollection(area.map.name + "::" + area.name);
 
         other.active = false;
         this.EightBitter.TimeHandler.addEvent(
@@ -1700,7 +1732,7 @@ export class Animations<TEightBittr extends FullScreenPokemon> extends EightBitt
                 other.active = true;
             },
             2);
-    }
+    };
 
     /**
      * Makes sure that Player is facing the correct HMCharacter

--- a/src/Collisions.ts
+++ b/src/Collisions.ts
@@ -397,6 +397,7 @@ export class Collisions<TEightBittr extends FullScreenPokemon> extends EightBitt
      *
      * @param thing   A Character walking to other.
      * @param other   A Ledge walked to by thing.
+     * @returns Whether the Character was able animate onto land.
      */
     public collideWaterEdge(thing: ICharacter, other: IThing): boolean {
         const edge: IWaterEdge = other as IWaterEdge;

--- a/src/IFullScreenPokemon.ts
+++ b/src/IFullScreenPokemon.ts
@@ -2289,16 +2289,6 @@ export interface IAreaGate extends IDetector {
     area: string;
 
     /**
-     * Horizontal spawning offset for the Area.
-     */
-    areaOffsetX: number;
-
-    /**
-     * Vertical spawning offset for the Area.
-     */
-    areaOffsetY: number;
-
-    /**
      * The Map to now spawn within.
      */
     map: string;

--- a/src/IFullScreenPokemon.ts
+++ b/src/IFullScreenPokemon.ts
@@ -2269,14 +2269,39 @@ export interface IWaterEdge extends IHMCharacter {
  */
 export interface IAreaSpawner extends IDetector {
     /**
-     * The name of the Map to retrieve the Area within.
-     */
-    map: string;
-
-    /**
      * The Area to add into the game.
      */
     area: string;
+
+    /**
+     * The name of the Map to retrieve the Area within.
+     */
+    map: string;
+}
+
+/**
+ * A Detector that marks a player as spawning in a different Area.
+ */
+export interface IAreaGate extends IDetector {
+    /**
+     * The Area to now spawn within.
+     */
+    area: string;
+
+    /**
+     * Horizontal spawning offset for the Area.
+     */
+    areaOffsetX: number;
+
+    /**
+     * Vertical spawning offset for the Area.
+     */
+    areaOffsetY: number;
+
+    /**
+     * The Map to now spawn within.
+     */
+    map: string;
 }
 
 /**

--- a/src/Maps.ts
+++ b/src/Maps.ts
@@ -207,26 +207,32 @@ export class Maps<TEightBittr extends FullScreenPokemon> extends GameStartr.Maps
 
         prething.direction = direction;
         switch (direction) {
-            case 0:
+            case Direction.Top:
                 prething.x = boundaries.left;
                 prething.y = boundaries.top - 8;
+                prething.width = boundaries.right - boundaries.left;
                 break;
-            case 1:
+
+            case Direction.Right:
                 prething.x = boundaries.right;
                 prething.y = boundaries.top;
                 prething.height = boundaries.bottom - boundaries.top;
                 break;
-            case 2:
+
+            case Direction.Bottom:
                 prething.x = boundaries.left;
                 prething.y = boundaries.bottom;
+                prething.width = boundaries.right - boundaries.left;
                 break;
-            case 3:
+
+            case Direction.Left:
                 prething.x = boundaries.left - 8;
                 prething.y = boundaries.top;
                 prething.height = boundaries.bottom - boundaries.top;
                 break;
+
             default:
-                throw new Error("Unknown direction: " + direction + ".");
+                throw new Error(`Unknown direction: '${direction}'.`);
         }
 
         this.EightBitter.MapsCreator.analyzePreSwitch(prething, prethings, area, map);
@@ -302,13 +308,19 @@ export class Maps<TEightBittr extends FullScreenPokemon> extends GameStartr.Maps
             case Direction.Top:
                 top -= area.height * this.EightBitter.unitsize;
                 break;
+
             case Direction.Right:
+                left += thing.width * this.EightBitter.unitsize;
                 break;
+
             case Direction.Bottom:
                 top += thing.height * this.EightBitter.unitsize;
                 break;
+
             case Direction.Left:
+                left -= area.width * this.EightBitter.unitsize;
                 break;
+
             default:
                 throw new Error(`Unknown direction: '${direction}'.`);
         }

--- a/src/Maps.ts
+++ b/src/Maps.ts
@@ -159,6 +159,11 @@ export class Maps<TEightBittr extends FullScreenPokemon> extends GameStartr.Maps
 
         this.EightBitter.PixelDrawer.setBackground((this.EightBitter.AreaSpawner.getArea() as IArea).background);
 
+        if (location.area.map.name !== "Blank") {
+            this.EightBitter.ItemsHolder.setItem("map", location.area.map.name);
+            this.EightBitter.ItemsHolder.setItem("area", location.area.name);
+            this.EightBitter.ItemsHolder.setItem("location", name);
+        }
         this.EightBitter.StateHolder.setCollection(location.area.map.name + "::" + location.area.name);
 
         this.EightBitter.QuadsKeeper.resetQuadrants();

--- a/src/Settings/Objects.ts
+++ b/src/Settings/Objects.ts
@@ -84,6 +84,7 @@ export function GenerateObjectsSettings(): GameStartr.IObjectMakrCustoms {
                     },
                     "Cabinet": {},
                     "CollisionDetector": {
+                        "AreaGate": {},
                         "CutsceneTriggerer": {},
                         "MenuTriggerer": {},
                         "SightDetector": {},
@@ -870,6 +871,11 @@ export function GenerateObjectsSettings(): GameStartr.IObjectMakrCustoms {
                 "collide": Collisions.prototype.collideCollisionDetector,
                 "active": false,
                 "hidden": true
+            },
+            "AreaGate": {
+                "activate": Animations.prototype.activateAreaGate,
+                "active": true,
+                "requireOverlap": true
             },
             "CutsceneTriggerer": {
                 "activate": Animations.prototype.activateCutsceneTriggerer,

--- a/src/Storage.ts
+++ b/src/Storage.ts
@@ -88,10 +88,7 @@ export class Storage<TEightBittr extends FullScreenPokemon> extends EightBittr.C
         }
 
         this.EightBitter.MenuGrapher.createMenu("GeneralText");
-        this.EightBitter.MenuGrapher.addMenuDialog(
-            "GeneralText", [
-                "Now saving..."
-            ]);
+        this.EightBitter.MenuGrapher.addMenuDialog("GeneralText", ["Now saving..."]);
 
         this.EightBitter.TimeHandler.addEvent(
             (): void => this.EightBitter.MenuGrapher.deleteAllMenus(),

--- a/src/Storage.ts
+++ b/src/Storage.ts
@@ -72,10 +72,6 @@ export class Storage<TEightBittr extends FullScreenPokemon> extends EightBittr.C
     public saveGame(showText: boolean = true): void {
         const ticksRecorded: number = this.EightBitter.FPSAnalyzer.getNumRecorded();
 
-        this.EightBitter.ItemsHolder.setItem("map", this.EightBitter.AreaSpawner.getMapName());
-        this.EightBitter.ItemsHolder.setItem("area", this.EightBitter.AreaSpawner.getAreaName());
-        this.EightBitter.ItemsHolder.setItem("location", this.EightBitter.AreaSpawner.getLocationEntered().name);
-
         this.EightBitter.ItemsHolder.increase("time", ticksRecorded - this.EightBitter.ticksElapsed);
         this.EightBitter.ticksElapsed = ticksRecorded;
 


### PR DESCRIPTION
Fixes #93.

Activating an `AreaSpawner` will drop an AreaGate that, when overlapped by the player, changes which area is current. It also shifts MapScreenr to pretend to have started in the new area so that saving xloc/yloc respects the new coordinates.