### PR TITLE
Added grid snapping on walking continuations

### DIFF
--- a/src/components/Actions.ts
+++ b/src/components/Actions.ts
@@ -127,20 +127,6 @@ export class Actions<TGameStartr extends FullScreenPokemon> extends Component<TG
     }
 
     /**
-     * Snaps a moving Thing to a predictable grid position.
-     * 
-     * @param thing   A Thing to snap the position of.
-     */
-    public animateSnapToGrid(thing: IThing): void {
-        const grid: number = 32;
-        const x: number = (this.gameStarter.mapScreener.left + thing.left) / grid;
-        const y: number = (this.gameStarter.mapScreener.top + thing.top) / grid;
-
-        this.gameStarter.physics.setLeft(thing, Math.round(x) * grid - this.gameStarter.mapScreener.left);
-        this.gameStarter.physics.setTop(thing, Math.round(y) * grid - this.gameStarter.mapScreener.top);
-    }
-
-    /**
      * Freezes a Character to start a dialog.
      * 
      * @param thing   A Player to freeze.

--- a/src/components/Physics.ts
+++ b/src/components/Physics.ts
@@ -127,6 +127,20 @@ export class Physics<TGameStartr extends FullScreenPokemon> extends GameStartrPh
     }
 
     /**
+     * Snaps a moving Thing to a predictable grid position.
+     * 
+     * @param thing   A Thing to snap the position of.
+     */
+    public snapToGrid(thing: IThing): void {
+        const grid: number = 32;
+        const x: number = (this.gameStarter.mapScreener.left + thing.left) / grid;
+        const y: number = (this.gameStarter.mapScreener.top + thing.top) / grid;
+
+        this.gameStarter.physics.setLeft(thing, Math.round(x) * grid - this.gameStarter.mapScreener.left);
+        this.gameStarter.physics.setTop(thing, Math.round(y) * grid - this.gameStarter.mapScreener.top);
+    }
+
+    /**
      * Standard Function to kill a Thing, which means marking it as dead and
      * clearing its numquads, resting, movement, and cycles. It will later be
      * removed by its maintain* Function.

--- a/src/components/actions/Walking.ts
+++ b/src/components/actions/Walking.ts
@@ -135,6 +135,8 @@ export class Walking<TGameStartr extends FullScreenPokemon> extends Component<TG
                 this.gameStarter.physics.getDirectionBetween(thing.follower, thing)!);
         }
 
+        this.gameStarter.physics.snapToGrid(thing);
+
         this.gameStarter.timeHandler.addEvent(
             (): void => this.continueWalking(thing, ticksPerBlock, onContinueWalking),
             ticksPerBlock);


### PR DESCRIPTION
Fixes #349, I think.

I'd like to eventually figure out what is causing walking characters to become offset by 1. Will file a followup issue.