### PR TITLE
Switched to userwrappr@0.7.2, gamestartr@0.7.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,28 +9,23 @@ A free HTML5 remake of the original Pokemon, expanded for modern browsing.
 
 ## Usage
 
-FSP uses the [UserWrappr](https://github.com/FullScreenShenanigans/UserWrappr) module to fill the available window size with a game screen, option menus, and piped input events.
-
 ```typescript
 import { FullScreenPokemon } from "fullscreenpokemon";
 
-const container = document.querySelector("#game");
-const fsp = new FullScreenPokemon();
+// Creates a new game with a 320x480 screen size.
+const fsp = new FullScreenPokemon({
+    height: 320,
+    width: 480,
+});
 
-fsp.userWrapper.createDisplay(container);
-```
-
-You can make just the game canvas without any wrapping input pipes or menus by directly calling `FSP.reset(size)`.
-The game will have a `.canvas` member displaying the game screen.
-You'll need to set up your own event registrations manually.
-
-```typescript
-const fsp = new FullScreenPokemon();
-
-fsp.reset(fsp.interface.sizes.GameBody);
-
+// Games contain a .canvas member for the screen.
 document.body.appendChild(fsp.canvas);
 ```
+
+By default, the game doesn't set up input events.
+You'll need to set up your own event registrations manually.
+
+The built `src/index.html` uses [UserWrappr](https://github.com/FullScreenShenanigans/UserWrappr) to fill the available window size with a game screen, option menus, and piped input events.
 
 <!-- {{Development}} -->
 ## Development

--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
         "battlemovr": "^0.7.1",
         "changelinr": "^0.7.0",
         "devicelayr": "^0.7.0",
-        "eightbittr": "^0.7.0",
+        "eightbittr": "^0.7.3",
         "flagswappr": "^0.7.1",
         "fpsanalyzr": "^0.7.0",
         "gamesrunnr": "^0.7.0",
-        "gamestartr": "^0.7.0",
+        "gamestartr": "^0.7.3",
         "groupholdr": "^0.7.0",
         "inputwritr": "^0.7.0",
         "itemsholdr": "^0.7.0",
@@ -36,7 +36,7 @@
         "thinghittr": "^0.7.0",
         "timehandlr": "^0.7.0",
         "touchpassr": "^0.7.0",
-        "userwrappr": "^0.7.0"
+        "userwrappr": "^0.7.2"
     },
     "description": "A free HTML5 remake of the original Pokemon, expanded for modern browsing.",
     "devDependencies": {

--- a/src/FullScreenPokemon.ts
+++ b/src/FullScreenPokemon.ts
@@ -4,7 +4,6 @@ import { GameStartr, IGameStartrSettings } from "gamestartr";
 import { IMenuGraphr, MenuGraphr } from "menugraphr";
 import { IScenePlayr, ScenePlayr } from "sceneplayr";
 import { IStateHoldr, StateHoldr } from "stateholdr";
-import { IUserWrappr, UserWrappr } from "userwrappr";
 
 import { Actions } from "./components/Actions";
 import { Battles } from "./components/Battles";
@@ -19,7 +18,6 @@ import { Fishing } from "./components/Fishing";
 import { Gameplay } from "./components/Gameplay";
 import { Graphics } from "./components/Graphics";
 import { Inputs } from "./components/Inputs";
-import { Interface } from "./components/Interface";
 import { Macros } from "./components/Macros";
 import { Maintenance } from "./components/Maintenance";
 import { IMapScreenr, Maps } from "./components/Maps";
@@ -82,11 +80,6 @@ export class FullScreenPokemon extends GameStartr {
      * General localStorage saving for collections of state.
      */
     public stateHolder: IStateHoldr;
-
-    /**
-     * General localStorage saving for collections of state.
-     */
-    public userWrapper: IUserWrappr;
 
     /**
      * Action functions used by this instance.
@@ -154,11 +147,6 @@ export class FullScreenPokemon extends GameStartr {
     public inputs: Inputs<FullScreenPokemon>;
 
     /**
-     * Interface functions used by this instance.
-     */
-    public interface: Interface<FullScreenPokemon>;
-
-    /**
      * Macro functions used by this instance.
      */
     public macros: Macros<FullScreenPokemon>;
@@ -219,17 +207,6 @@ export class FullScreenPokemon extends GameStartr {
     public ticksElapsed: number;
 
     /**
-     * Initializes a new instance of the FullScreenPokemon class.
-     */
-    public constructor() {
-        super();
-
-        this.mods = new Mods(this);
-        this.interface = new Interface(this);
-        this.userWrapper = new UserWrappr(this.interface.generateUserWrapprSettings());
-    }
-
-    /**
      * Resets the system components.
      */
     protected resetComponents(): void {
@@ -244,6 +221,7 @@ export class FullScreenPokemon extends GameStartr {
         this.maintenance = new Maintenance(this);
         this.maps = new Maps(this);
         this.menus = new Menus(this);
+        this.mods = new Mods(this);
         this.physics = new Physics(this);
         this.things = new Things(this);
         this.scrolling = new Scrolling(this);

--- a/src/components/Mods.ts
+++ b/src/components/Mods.ts
@@ -7,6 +7,7 @@ import { EventNames } from "./mods/EventNames";
 import { InfiniteRepelMod } from "./mods/InfiniteRepelMod";
 import { JoeysRattataMod } from "./mods/JoeysRattataMod";
 import { Level100Mod } from "./mods/Level100Mod";
+import { ModComponent } from "./mods/ModComponent";
 import { NuzlockeChallengeMod } from "./mods/NuzlockeChallengeMod";
 import { RandomHeldItemsMod } from "./mods/RandomHeldItemsMod";
 import { RandomizeWildPokemonMod } from "./mods/RandomizeWildPokemonMod";
@@ -17,29 +18,52 @@ import { SpeedRunningMod } from "./mods/SpeedRunningMod";
 import { WalkThroughWallsMod } from "./mods/WalkThroughWallsMod";
 
 /**
+ * Class for a mod component.
+ */
+export interface IModComponentClass {
+    /**
+     * Name of the mod.
+     */
+    modName: string;
+
+    new<TGameStartr extends FullScreenPokemon>(gameStarter: TGameStartr, eventNames: EventNames): ModComponent<TGameStartr>;
+}
+
+/**
  * Mods used by FullScreenPokemon instances.
  */
 export class Mods<TGameStartr extends FullScreenPokemon> extends Component<TGameStartr> {
+    /**
+     * Classes for known mods.
+     */
+    public static readonly modClasses: IModComponentClass[] = [
+        BlindTrainersMod,
+        InfiniteRepelMod,
+        JoeysRattataMod,
+        Level100Mod,
+        NuzlockeChallengeMod,
+        RandomHeldItemsMod,
+        RandomizeWildPokemonMod,
+        RepeatTrainersMod,
+        RunningIndoorsMod,
+        ScalingLevelsMod,
+        SpeedRunningMod,
+        WalkThroughWallsMod,
+    ];
+
     /**
      * Keys for mod events.
      */
     public readonly eventNames: EventNames = new EventNames();
 
     /**
+     * Known mods, keyed by mod name.
+     */
+    public readonly modsByName: { [i: string]: IMod } = {};
+
+    /**
      * General schemas for known mods, including names and events.
      */
-    public readonly mods: IMod[] = [
-        new BlindTrainersMod(this.gameStarter, this.eventNames),
-        new InfiniteRepelMod(this.gameStarter, this.eventNames),
-        new JoeysRattataMod(this.gameStarter, this.eventNames),
-        new Level100Mod(this.gameStarter, this.eventNames),
-        new NuzlockeChallengeMod(this.gameStarter, this.eventNames),
-        new RandomHeldItemsMod(this.gameStarter, this.eventNames),
-        new RandomizeWildPokemonMod(this.gameStarter, this.eventNames),
-        new RepeatTrainersMod(this.gameStarter, this.eventNames),
-        new RunningIndoorsMod(this.gameStarter, this.eventNames),
-        new ScalingLevelsMod(this.gameStarter, this.eventNames),
-        new SpeedRunningMod(this.gameStarter, this.eventNames),
-        new WalkThroughWallsMod(this.gameStarter, this.eventNames),
-    ];
+    public readonly mods: IMod[] = Mods.modClasses.map(
+        (modClass) => this.modsByName[modClass.modName] = new modClass(this.gameStarter, this.eventNames));
 }

--- a/src/components/mods/BlindTrainersMod.ts
+++ b/src/components/mods/BlindTrainersMod.ts
@@ -10,7 +10,7 @@ export class BlindTrainersMod<TGameStartr extends FullScreenPokemon> extends Mod
     /**
      * Name of the mod.
      */
-    public readonly name: string = "Blind Trainers";
+    public static readonly modName: string = "Blind Trainers";
 
     /**
      * Mod events, keyed by name.

--- a/src/components/mods/InfiniteRepelMod.ts
+++ b/src/components/mods/InfiniteRepelMod.ts
@@ -10,7 +10,7 @@ export class InfiniteRepelMod<TGameStartr extends FullScreenPokemon> extends Mod
     /**
      * Name of the mod.
      */
-    public readonly name: string = "Infinite Repel";
+    public static readonly modName: string = "Infinite Repel";
 
     /**
      * Mod events, keyed by name.

--- a/src/components/mods/JoeysRattataMod.ts
+++ b/src/components/mods/JoeysRattataMod.ts
@@ -11,7 +11,7 @@ export class JoeysRattataMod<TGameStartr extends FullScreenPokemon> extends ModC
     /**
      * Name of the mod.
      */
-    public readonly name: string = "Joey's Rattata";
+    public static readonly modName: string = "Joey's Rattata";
 
     /**
      * Mod events, keyed by name.

--- a/src/components/mods/Level100Mod.ts
+++ b/src/components/mods/Level100Mod.ts
@@ -11,7 +11,7 @@ export class Level100Mod<TGameStartr extends FullScreenPokemon> extends ModCompo
     /**
      * Name of the mod.
      */
-    public readonly name: string = "Level 100";
+    public static readonly modName: string = "Level 100";
 
     /**
      * Mod events, keyed by name.

--- a/src/components/mods/ModComponent.ts
+++ b/src/components/mods/ModComponent.ts
@@ -2,6 +2,7 @@ import { Component } from "eightbittr";
 import { ICallbackRegister, IMod } from "modattachr";
 
 import { FullScreenPokemon } from "../../FullScreenPokemon";
+import { IModComponentClass } from "../Mods";
 import { EventNames } from "./EventNames";
 
 /**
@@ -11,7 +12,9 @@ export abstract class ModComponent<TGameStartr extends FullScreenPokemon> extend
     /**
      * Name of the mod.
      */
-    public abstract readonly name: string;
+    public get name(): string {
+        return (this.constructor as IModComponentClass).modName;
+    }
 
     /**
      * Mod events, keyed by name.

--- a/src/components/mods/NuzlockeChallengeMod.ts
+++ b/src/components/mods/NuzlockeChallengeMod.ts
@@ -14,7 +14,7 @@ export class NuzlockeChallengeMod<TGameStartr extends FullScreenPokemon> extends
     /**
      * Name of the mod.
      */
-    public readonly name: string = "Nuzlocke Challenge";
+    public static readonly modName: string = "Nuzlocke Challenge";
 
     /**
      * Mod events, keyed by name.

--- a/src/components/mods/RandomHeldItemsMod.ts
+++ b/src/components/mods/RandomHeldItemsMod.ts
@@ -23,13 +23,18 @@ export interface IItemProbabilities {
   * Mod that randomizes items found on wild Pokemon.
   */
 export class RandomHeldItemsMod<TGameStartr extends FullScreenPokemon> extends ModComponent<TGameStartr> implements IMod {
+     /**
+      * Name of the mod.
+      */
+    public static readonly modName: string = "Random Held Items";
+
     /**
      * What items can be found on wild Pokemon by their primary type.
      *
      * @remarks No need to make probabilites add to 1 as the mod will just pick no item if generated
      *          number is higher than what the probabilities add up to.
      */
-     private static typeItems: { [i: string]: IItemProbabilities[] } = {
+    private static typeItems: { [i: string]: IItemProbabilities[] } = {
         Normal: [
             {
                 name: "Potion",
@@ -155,14 +160,9 @@ export class RandomHeldItemsMod<TGameStartr extends FullScreenPokemon> extends M
      };
 
      /**
-      * Name of the mod.
-      */
-     public readonly name: string = "Random Held Items";
-
-     /**
       * Mod events, keyed by name.
       */
-     public readonly events: ICallbackRegister = {
+    public readonly events: ICallbackRegister = {
          [this.eventNames.onNewPokemonCreation]: (chosenInfo: INewPokemon) => {
              const pokemonName: string = chosenInfo.title.join("");
              const pokemonType: string = this.gameStarter.constants.pokemon.byName[pokemonName].types[0];
@@ -180,7 +180,7 @@ export class RandomHeldItemsMod<TGameStartr extends FullScreenPokemon> extends M
       * @param pokemonType   Type of the wild encountered Pokemon.
       * @returns The name of an item or undefined if no item generated.
       */
-     private randomHeldItemGenerator(pokemonType: string): string[] | undefined {
+    private randomHeldItemGenerator(pokemonType: string): string[] | undefined {
             const probabilityOfHeldItem: number = this.gameStarter.numberMaker.randomReal1();
             let counter = 0;
 

--- a/src/components/mods/RandomizeWildPokemonMod.ts
+++ b/src/components/mods/RandomizeWildPokemonMod.ts
@@ -11,7 +11,7 @@ export class RandomizeWildPokemonMod<TGameStartr extends FullScreenPokemon> exte
     /**
      * Name of the mod.
      */
-    public readonly name: string = "Randomize Wild Pokemon";
+    public static readonly modName: string = "Randomize Wild Pokemon";
 
     /**
      * Mod events, keyed by name.

--- a/src/components/mods/RepeatTrainersMod.ts
+++ b/src/components/mods/RepeatTrainersMod.ts
@@ -11,7 +11,7 @@ export class RepeatTrainersMod<TGameStartr extends FullScreenPokemon> extends Mo
     /**
      * Name of the mod.
      */
-    public readonly name: string = "Repeat Trainers";
+    public static readonly modName: string = "Repeat Trainers";
 
     /**
      * Mod events, keyed by name.

--- a/src/components/mods/RunningIndoorsMod.ts
+++ b/src/components/mods/RunningIndoorsMod.ts
@@ -11,7 +11,7 @@ export class RunningIndoorsMod<TGameStartr extends FullScreenPokemon> extends Mo
     /**
      * Name of the mod.
      */
-    public readonly name: string = "Running Indoors";
+    public static readonly modName: string = "Running Indoors";
 
     /**
      * Mod events, keyed by name.

--- a/src/components/mods/ScalingLevelsMod.ts
+++ b/src/components/mods/ScalingLevelsMod.ts
@@ -13,7 +13,7 @@ export class ScalingLevelsMod<TGameStartr extends FullScreenPokemon> extends Mod
     /**
      * Name of the mod.
      */
-    public readonly name: string = "Scaling Levels";
+    public static readonly modName: string = "Scaling Levels";
 
     /**
      * Mod events, keyed by name.

--- a/src/components/mods/SpeedRunningMod.ts
+++ b/src/components/mods/SpeedRunningMod.ts
@@ -10,12 +10,12 @@ export class SpeedRunningMod<TGameStartr extends FullScreenPokemon> extends ModC
     /**
      * Class name for the player's prototype.
      */
-    private static playerClassName = "Player";
+    private static readonly playerClassName = "Player";
 
     /**
      * Name of the mod.
      */
-    public readonly name: string = "Speed Running";
+    public static readonly modName: string = "Speed Running";
 
     /**
      * Mod events, keyed by name.

--- a/src/components/mods/WalkThroughWallsMod.ts
+++ b/src/components/mods/WalkThroughWallsMod.ts
@@ -10,7 +10,7 @@ export class WalkThroughWallsMod<TGameStartr extends FullScreenPokemon> extends 
     /**
      * Name of the mod.
      */
-    public readonly name: string = "Walk Through Walls";
+    public static readonly modName: string = "Walk Through Walls";
 
     /**
      * Mod events, keyed by name.

--- a/src/fakes.test.ts
+++ b/src/fakes.test.ts
@@ -14,16 +14,15 @@ export const stubFullScreenPokemon = (settings?: IFullScreenPokemonSettings): Fu
         height: 256,
     };
 
-    const fsp = new FullScreenPokemon()
-        .reset({
-            height: settings.height || 256,
-            moduleSettings: {
-                audio: {
-                    fileTypes: [],
-                },
+    const fsp = new FullScreenPokemon({
+        height: settings.height || 256,
+        moduleSettings: {
+            audio: {
+                fileTypes: [],
             },
-            width: settings.width || 256,
-        });
+        },
+        width: settings.width || 256,
+    });
 
     stub(fsp.audioPlayer, "play");
     stub(fsp.audioPlayer, "playLocal");

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,12 @@
-import { FullScreenPokemon } from "./FullScreenPokemon";
+import { UserWrappr } from "userwrappr";
+
+import { InterfaceFactory } from "./InterfaceFactory";
 
 const container = document.getElementById("game")!;
-const FSP: FullScreenPokemon = new FullScreenPokemon();
+const interfaceFactory = new InterfaceFactory();
+const userWrapper = new UserWrappr(interfaceFactory.generateUserWrapprSettings());
 
-FSP.userWrapper.createDisplay(container)
+userWrapper.createDisplay(container)
     .then((): void => {
         container.className += " loaded";
     })
@@ -11,5 +14,3 @@ FSP.userWrapper.createDisplay(container)
         console.error("An error happened while trying to instantiate FullScreenPokemon!");
         console.error(error);
     });
-
-(window as any).FSP = FSP;


### PR DESCRIPTION
Constructor takes in size settings instead of waiting to reset. This way, the game is always guaranteed to have modules & components - which is less confusing for the type system. UserWrappr logic needs mod names before instantiating the game, so the names are now static members of the `ModComponent` classes accessed with a getter. An `InterfaceFactory` instantiates the UserWrappr logic.