### PR TITLE
Added an InstantTransition for quick battle entries

### DIFF
--- a/src/components/battles/animations/Transitions.ts
+++ b/src/components/battles/animations/Transitions.ts
@@ -2,6 +2,7 @@ import { GeneralComponent } from "gamestartr";
 
 import { FullScreenPokemon } from "../../../FullScreenPokemon";
 import { FlashTransition } from "./transitions/FlashTransition";
+import { InstantTransition } from "./transitions/InstantTransition";
 import { Transition } from "./transitions/Transition";
 
 /**
@@ -35,6 +36,7 @@ export class Transitions<TGameStartr extends FullScreenPokemon> extends GeneralC
      */
     private readonly transitions: ITransitions = {
         flash: FlashTransition,
+        instant: InstantTransition,
     };
 
     /**

--- a/src/components/battles/animations/transitions/InstantTransition.ts
+++ b/src/components/battles/animations/transitions/InstantTransition.ts
@@ -1,0 +1,17 @@
+import { FullScreenPokemon } from "../../../../FullScreenPokemon";
+
+import { Transition } from "./Transition";
+
+/**
+ * Instantly-completing battle transition animation.
+ *
+ * @remarks Useful for tests!
+ */
+export class InstantTransition<TGameStartr extends FullScreenPokemon> extends Transition<TGameStartr> {
+    /**
+     * Plays and immediately finishes the transition.
+     */
+    public play(): void {
+        this.settings.onComplete();
+    }
+}


### PR DESCRIPTION
### Summary

Adds an `InstantTransition` battle entry transition that instantly completes. Tests will be able to use it to start battles instantly.

Addresses #630 
