### PR TITLE
Prevent all event defaults; increased quadrants size

### DIFF
--- a/src/components/Inputs.ts
+++ b/src/components/Inputs.ts
@@ -44,7 +44,7 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
      * @param event   The original user-caused Event.
      */
     public keyDownUp(thing: ICharacter, event?: Event): void {
-        if (!this.canDirectionsTrigger(thing)) {
+        if (!this.gameStarter.gameplay.canInputsTrigger(event) || !this.canDirectionsTrigger(thing)) {
             return;
         }
 
@@ -57,10 +57,6 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
             this.inputTimeTolerance);
 
         this.gameStarter.modAttacher.fireEvent(this.gameStarter.mods.eventNames.onKeyDownUp);
-
-        if (event && event.preventDefault) {
-            event.preventDefault();
-        }
     }
 
     /**
@@ -71,7 +67,7 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
      * @param event   The original user-caused Event.
      */
     public keyDownRight(thing: ICharacter, event?: Event): void {
-        if (!this.canDirectionsTrigger(thing)) {
+        if (!this.gameStarter.gameplay.canInputsTrigger(event) || !this.canDirectionsTrigger(thing)) {
             return;
         }
 
@@ -82,10 +78,6 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
         this.gameStarter.timeHandler.addEvent(
             (): void => this.keyDownDirectionReal(thing as IPlayer, Direction.Right),
             this.inputTimeTolerance);
-
-        if (event && event.preventDefault) {
-            event.preventDefault();
-        }
     }
 
     /**
@@ -96,7 +88,7 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
      * @param event   The original user-caused Event.
      */
     public keyDownDown(thing: ICharacter, event?: Event): void {
-        if (!this.canDirectionsTrigger(thing)) {
+        if (!this.gameStarter.gameplay.canInputsTrigger(event) || !this.canDirectionsTrigger(thing)) {
             return;
         }
 
@@ -109,10 +101,6 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
             this.inputTimeTolerance);
 
         this.gameStarter.modAttacher.fireEvent(this.gameStarter.mods.eventNames.onKeyDownDown);
-
-        if (event && event.preventDefault) {
-            event.preventDefault();
-        }
     }
 
     /**
@@ -123,7 +111,7 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
      * @param event   The original user-caused Event.
      */
     public keyDownLeft(thing: ICharacter, event?: Event): void {
-        if (!this.canDirectionsTrigger(thing)) {
+        if (!this.gameStarter.gameplay.canInputsTrigger(event) || !this.canDirectionsTrigger(thing)) {
             return;
         }
 
@@ -136,10 +124,6 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
             this.inputTimeTolerance);
 
         this.gameStarter.modAttacher.fireEvent(this.gameStarter.mods.eventNames.onKeyDownLeft);
-
-        if (event && event.preventDefault) {
-            event.preventDefault();
-        }
     }
 
     /**
@@ -150,7 +134,7 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
      * @param thing   The triggering Character.
      * @param event   The original user-caused Event.
      */
-    protected keyDownDirectionReal(thing: IPlayer, direction: Direction): void {
+    private keyDownDirectionReal(thing: IPlayer, direction: Direction): void {
         if (!(thing.keys as any)[direction]) {
             return;
         }
@@ -178,7 +162,7 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
      * @param event   The original user-caused Event.
      */
     public keyDownA(thing: ICharacter, event?: Event): void {
-        if (this.gameStarter.gamesRunner.getPaused()) {
+        if (!this.gameStarter.gameplay.canInputsTrigger(event) || this.gameStarter.gamesRunner.getPaused()) {
             return;
         }
 
@@ -198,10 +182,6 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
         }
 
         this.gameStarter.modAttacher.fireEvent(this.gameStarter.mods.eventNames.onKeyDownA);
-
-        if (event && event.preventDefault) {
-            event.preventDefault();
-        }
     }
 
     /**
@@ -212,7 +192,7 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
      * @param event   The original user-caused Event.
      */
     public keyDownB(thing: ICharacter, event?: Event): void {
-        if (this.gameStarter.gamesRunner.getPaused()) {
+        if (!this.gameStarter.gameplay.canInputsTrigger(event) || this.gameStarter.gamesRunner.getPaused()) {
             return;
         }
 
@@ -223,10 +203,6 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
         }
 
         this.gameStarter.modAttacher.fireEvent(this.gameStarter.mods.eventNames.onKeyDownB);
-
-        if (event && event.preventDefault) {
-            event.preventDefault();
-        }
     }
 
     /**
@@ -237,12 +213,10 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
      * @param event   The original user-caused Event.
      */
     public keyDownPause(_thing: ICharacter, event?: Event): void {
+        this.gameStarter.gameplay.canInputsTrigger(event);
+
         this.gameStarter.menus.pause.toggle();
         this.gameStarter.modAttacher.fireEvent(this.gameStarter.mods.eventNames.onKeyDownPause);
-
-        if (event && event.preventDefault) {
-            event.preventDefault();
-        }
     }
 
     /**
@@ -253,12 +227,9 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
      * @param event   The original user-caused Event.
      */
     public async keyDownMute(_thing: ICharacter, event?: Event): Promise<void> {
+        this.gameStarter.gameplay.canInputsTrigger(event);
         await this.gameStarter.audioPlayer.setMuted(this.gameStarter.audioPlayer.getMuted());
         this.gameStarter.modAttacher.fireEvent(this.gameStarter.mods.eventNames.onKeyDownMute);
-
-        if (event && event.preventDefault) {
-            event.preventDefault();
-        }
     }
 
     /**
@@ -269,7 +240,7 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
      * @todo Extend the use for any registered item, not just the bicycle.
      */
     public keyDownSelect(thing: IPlayer, event?: Event): void {
-        if (this.gameStarter.menuGrapher.getActiveMenu() || thing.walking) {
+        if (!this.gameStarter.gameplay.canInputsTrigger(event) || this.gameStarter.menuGrapher.getActiveMenu() || thing.walking) {
             return;
         }
 
@@ -288,10 +259,6 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
         if (!itemSchema.bagActivate.call(this, thing, itemSchema)) {
             this.gameStarter.menus.displayMessage(itemSchema.error || "");
         }
-
-        if (event && event.preventDefault) {
-            event.preventDefault();
-        }
     }
 
     /**
@@ -301,6 +268,7 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
      * @param event   The original user-caused Event.
      */
     public keyUpLeft(thing: ICharacter, event?: Event): void {
+        this.gameStarter.gameplay.canInputsTrigger(event);
         this.gameStarter.modAttacher.fireEvent(this.gameStarter.mods.eventNames.onKeyUpLeft);
 
         if (thing.player) {
@@ -313,10 +281,6 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
         } else if (thing.nextDirection === undefined) {
             thing.wantsToWalk = false;
         }
-
-        if (event && event.preventDefault) {
-            event.preventDefault();
-        }
     }
 
     /**
@@ -326,6 +290,7 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
      * @param event   The original user-caused Event.
      */
     public keyUpRight(thing: ICharacter, event?: Event): void {
+        this.gameStarter.gameplay.canInputsTrigger(event);
         this.gameStarter.modAttacher.fireEvent(this.gameStarter.mods.eventNames.onKeyUpRight);
 
         if (thing.player) {
@@ -338,10 +303,6 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
         } else if (thing.nextDirection === undefined) {
             thing.wantsToWalk = false;
         }
-
-        if (event && event.preventDefault) {
-            event.preventDefault();
-        }
     }
 
     /**
@@ -351,6 +312,7 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
      * @param event   The original user-caused Event.
      */
     public keyUpUp(thing: ICharacter, event?: Event): void {
+        this.gameStarter.gameplay.canInputsTrigger(event);
         this.gameStarter.modAttacher.fireEvent(this.gameStarter.mods.eventNames.onKeyUpUp);
 
         if (thing.player) {
@@ -363,10 +325,6 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
         } else if (thing.nextDirection === undefined) {
             thing.wantsToWalk = false;
         }
-
-        if (event && event.preventDefault) {
-            event.preventDefault();
-        }
     }
 
     /**
@@ -376,6 +334,7 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
      * @param event   The original user-caused Event.
      */
     public keyUpDown(thing: ICharacter, event?: Event): void {
+        this.gameStarter.gameplay.canInputsTrigger(event);
         this.gameStarter.modAttacher.fireEvent(this.gameStarter.mods.eventNames.onKeyUpDown);
 
         if (thing.player) {
@@ -388,10 +347,6 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
         } else if (thing.nextDirection === undefined) {
             thing.wantsToWalk = false;
         }
-
-        if (event && event.preventDefault) {
-            event.preventDefault();
-        }
     }
 
     /**
@@ -401,14 +356,11 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
      * @param event   The original user-caused Event.
      */
     public keyUpA(thing: ICharacter, event?: Event): void {
+        this.gameStarter.gameplay.canInputsTrigger(event);
         this.gameStarter.modAttacher.fireEvent(this.gameStarter.mods.eventNames.onKeyUpA);
 
         if (thing.player) {
             (thing as IPlayer).keys.a = false;
-        }
-
-        if (event && event.preventDefault) {
-            event.preventDefault();
         }
     }
 
@@ -419,14 +371,11 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
      * @param event   The original user-caused Event.
      */
     public keyUpB(thing: ICharacter, event?: Event): void {
+        this.gameStarter.gameplay.canInputsTrigger(event);
         this.gameStarter.modAttacher.fireEvent(this.gameStarter.mods.eventNames.onKeyUpB);
 
         if (thing.player) {
             (thing as IPlayer).keys.b = false;
-        }
-
-        if (event && event.preventDefault) {
-            event.preventDefault();
         }
     }
 
@@ -437,11 +386,8 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
      * @param event   The original user-caused Event.
      */
     public keyUpPause(_thing: ICharacter, event?: Event): void {
+        this.gameStarter.gameplay.canInputsTrigger(event);
         this.gameStarter.modAttacher.fireEvent(this.gameStarter.mods.eventNames.onKeyUpPause);
-
-        if (event && event.preventDefault) {
-            event.preventDefault();
-        }
     }
 
     /**
@@ -452,11 +398,8 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
      * @param event   The original user-caused Event.
      */
     public mouseDownRight(_thing: ICharacter, event?: Event): void {
+        this.gameStarter.gameplay.canInputsTrigger(event);
         this.gameStarter.menus.pause.toggle();
         this.gameStarter.modAttacher.fireEvent(this.gameStarter.mods.eventNames.onMouseDownRight);
-
-        if (event && event.preventDefault) {
-            event.preventDefault();
-        }
     }
 }

--- a/src/components/Inputs.ts
+++ b/src/components/Inputs.ts
@@ -3,7 +3,7 @@ import { GeneralComponent } from "gamestartr";
 import { FullScreenPokemon } from "../FullScreenPokemon";
 import { Direction } from "./Constants";
 import { IItemSchema } from "./constants/Items";
-import { ICharacter, IPlayer } from "./Things";
+import { IPlayer } from "./Things";
 
 /**
  * Routes user input.
@@ -20,7 +20,7 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
      * @param thing   A Character that wants to move.
      * @returns Whether direction keys may trigger.
      */
-    public canDirectionsTrigger(thing: ICharacter): boolean {
+    public canDirectionsTrigger(thing: IPlayer): boolean {
         if (thing.following || thing.ledge) {
             return false;
         }
@@ -43,14 +43,12 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
      * @param thing   The triggering Character.
      * @param event   The original user-caused Event.
      */
-    public keyDownUp(thing: ICharacter, event?: Event): void {
+    public keyDownUp(thing: IPlayer, event?: Event): void {
         if (!this.gameStarter.gameplay.canInputsTrigger(event) || !this.canDirectionsTrigger(thing)) {
             return;
         }
 
-        if (thing.player) {
-            (thing as IPlayer).keys[Direction.Top] = true;
-        }
+        thing.keys[Direction.Top] = true;
 
         this.gameStarter.timeHandler.addEvent(
             (): void => this.keyDownDirectionReal(thing as IPlayer, Direction.Top),
@@ -66,14 +64,12 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
      * @param thing   The triggering Character.
      * @param event   The original user-caused Event.
      */
-    public keyDownRight(thing: ICharacter, event?: Event): void {
+    public keyDownRight(thing: IPlayer, event?: Event): void {
         if (!this.gameStarter.gameplay.canInputsTrigger(event) || !this.canDirectionsTrigger(thing)) {
             return;
         }
 
-        if (thing.player) {
-            (thing as IPlayer).keys[Direction.Right] = true;
-        }
+        thing.keys[Direction.Right] = true;
 
         this.gameStarter.timeHandler.addEvent(
             (): void => this.keyDownDirectionReal(thing as IPlayer, Direction.Right),
@@ -87,14 +83,12 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
      * @param thing   The triggering Character.
      * @param event   The original user-caused Event.
      */
-    public keyDownDown(thing: ICharacter, event?: Event): void {
+    public keyDownDown(thing: IPlayer, event?: Event): void {
         if (!this.gameStarter.gameplay.canInputsTrigger(event) || !this.canDirectionsTrigger(thing)) {
             return;
         }
 
-        if (thing.player) {
-            (thing as IPlayer).keys[Direction.Bottom] = true;
-        }
+        thing.keys[Direction.Bottom] = true;
 
         this.gameStarter.timeHandler.addEvent(
             (): void => this.keyDownDirectionReal(thing as IPlayer, Direction.Bottom),
@@ -110,14 +104,12 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
      * @param thing   The triggering Character.
      * @param event   The original user-caused Event.
      */
-    public keyDownLeft(thing: ICharacter, event?: Event): void {
+    public keyDownLeft(thing: IPlayer, event?: Event): void {
         if (!this.gameStarter.gameplay.canInputsTrigger(event) || !this.canDirectionsTrigger(thing)) {
             return;
         }
 
-        if (thing.player) {
-            (thing as IPlayer).keys[Direction.Left] = true;
-        }
+        thing.keys[Direction.Left] = true;
 
         this.gameStarter.timeHandler.addEvent(
             (): void => this.keyDownDirectionReal(thing as IPlayer, Direction.Left),
@@ -161,7 +153,7 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
      * @param thing   The triggering Character.
      * @param event   The original user-caused Event.
      */
-    public keyDownA(thing: ICharacter, event?: Event): void {
+    public keyDownA(thing: IPlayer, event?: Event): void {
         if (!this.gameStarter.gameplay.canInputsTrigger(event) || this.gameStarter.gamesRunner.getPaused()) {
             return;
         }
@@ -176,8 +168,8 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
                     thing.bordering[thing.direction]);
             }
 
-            if ((thing as IPlayer).keys) {
-                (thing as IPlayer).keys.a = true;
+            if (thing.keys) {
+                thing.keys.a = true;
             }
         }
 
@@ -191,15 +183,15 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
      * @param thing   The triggering Character.
      * @param event   The original user-caused Event.
      */
-    public keyDownB(thing: ICharacter, event?: Event): void {
+    public keyDownB(thing: IPlayer, event?: Event): void {
         if (!this.gameStarter.gameplay.canInputsTrigger(event) || this.gameStarter.gamesRunner.getPaused()) {
             return;
         }
 
         if (this.gameStarter.menuGrapher.getActiveMenu()) {
             this.gameStarter.menuGrapher.registerB();
-        } else if ((thing as IPlayer).keys) {
-            (thing as IPlayer).keys.b = true;
+        } else if (thing.keys) {
+            thing.keys.b = true;
         }
 
         this.gameStarter.modAttacher.fireEvent(this.gameStarter.mods.eventNames.onKeyDownB);
@@ -212,7 +204,7 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
      * @param _thing   The triggering Character.
      * @param event   The original user-caused Event.
      */
-    public keyDownPause(_thing: ICharacter, event?: Event): void {
+    public keyDownPause(_thing: IPlayer, event?: Event): void {
         this.gameStarter.gameplay.canInputsTrigger(event);
 
         this.gameStarter.menus.pause.toggle();
@@ -226,7 +218,7 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
      * @param _thing   The triggering Character.
      * @param event   The original user-caused Event.
      */
-    public async keyDownMute(_thing: ICharacter, event?: Event): Promise<void> {
+    public async keyDownMute(_thing: IPlayer, event?: Event): Promise<void> {
         this.gameStarter.gameplay.canInputsTrigger(event);
         await this.gameStarter.audioPlayer.setMuted(this.gameStarter.audioPlayer.getMuted());
         this.gameStarter.modAttacher.fireEvent(this.gameStarter.mods.eventNames.onKeyDownMute);
@@ -267,13 +259,11 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
      * @param thing   The triggering Character.
      * @param event   The original user-caused Event.
      */
-    public keyUpLeft(thing: ICharacter, event?: Event): void {
+    public keyUpLeft(thing: IPlayer, event?: Event): void {
         this.gameStarter.gameplay.canInputsTrigger(event);
         this.gameStarter.modAttacher.fireEvent(this.gameStarter.mods.eventNames.onKeyUpLeft);
 
-        if (thing.player) {
-            (thing as IPlayer).keys[Direction.Left] = false;
-        }
+        thing.keys[Direction.Left] = false;
 
         if (thing.nextDirection === Direction.Left) {
             thing.nextDirection = undefined;
@@ -289,13 +279,11 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
      * @param thing   The triggering Character.
      * @param event   The original user-caused Event.
      */
-    public keyUpRight(thing: ICharacter, event?: Event): void {
+    public keyUpRight(thing: IPlayer, event?: Event): void {
         this.gameStarter.gameplay.canInputsTrigger(event);
         this.gameStarter.modAttacher.fireEvent(this.gameStarter.mods.eventNames.onKeyUpRight);
 
-        if (thing.player) {
-            (thing as IPlayer).keys[Direction.Right] = false;
-        }
+        thing.keys[Direction.Right] = false;
 
         if (thing.nextDirection === Direction.Right) {
             thing.nextDirection = undefined;
@@ -311,13 +299,11 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
      * @param thing   The triggering Character.
      * @param event   The original user-caused Event.
      */
-    public keyUpUp(thing: ICharacter, event?: Event): void {
+    public keyUpUp(thing: IPlayer, event?: Event): void {
         this.gameStarter.gameplay.canInputsTrigger(event);
         this.gameStarter.modAttacher.fireEvent(this.gameStarter.mods.eventNames.onKeyUpUp);
 
-        if (thing.player) {
-            (thing as IPlayer).keys[0] = false;
-        }
+        thing.keys[0] = false;
 
         if (thing.nextDirection === Direction.Top) {
             thing.nextDirection = undefined;
@@ -333,13 +319,11 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
      * @param thing   The triggering Character.
      * @param event   The original user-caused Event.
      */
-    public keyUpDown(thing: ICharacter, event?: Event): void {
+    public keyUpDown(thing: IPlayer, event?: Event): void {
         this.gameStarter.gameplay.canInputsTrigger(event);
         this.gameStarter.modAttacher.fireEvent(this.gameStarter.mods.eventNames.onKeyUpDown);
 
-        if (thing.player) {
-            (thing as IPlayer).keys[2] = false;
-        }
+        thing.keys[2] = false;
 
         if (thing.nextDirection === Direction.Bottom) {
             thing.nextDirection = undefined;
@@ -355,13 +339,11 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
      * @param thing   The triggering Character.
      * @param event   The original user-caused Event.
      */
-    public keyUpA(thing: ICharacter, event?: Event): void {
+    public keyUpA(thing: IPlayer, event?: Event): void {
         this.gameStarter.gameplay.canInputsTrigger(event);
         this.gameStarter.modAttacher.fireEvent(this.gameStarter.mods.eventNames.onKeyUpA);
 
-        if (thing.player) {
-            (thing as IPlayer).keys.a = false;
-        }
+        thing.keys.a = false;
     }
 
     /**
@@ -370,13 +352,11 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
      * @param thing   The triggering Character.
      * @param event   The original user-caused Event.
      */
-    public keyUpB(thing: ICharacter, event?: Event): void {
+    public keyUpB(thing: IPlayer, event?: Event): void {
         this.gameStarter.gameplay.canInputsTrigger(event);
         this.gameStarter.modAttacher.fireEvent(this.gameStarter.mods.eventNames.onKeyUpB);
 
-        if (thing.player) {
-            (thing as IPlayer).keys.b = false;
-        }
+        thing.keys.b = false;
     }
 
     /**
@@ -385,7 +365,7 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
      * @param _thing   The triggering Character.
      * @param event   The original user-caused Event.
      */
-    public keyUpPause(_thing: ICharacter, event?: Event): void {
+    public keyUpPause(_thing: IPlayer, event?: Event): void {
         this.gameStarter.gameplay.canInputsTrigger(event);
         this.gameStarter.modAttacher.fireEvent(this.gameStarter.mods.eventNames.onKeyUpPause);
     }
@@ -397,7 +377,7 @@ export class Inputs<TGameStartr extends FullScreenPokemon> extends GeneralCompon
      * @param _thing   The triggering Character.
      * @param event   The original user-caused Event.
      */
-    public mouseDownRight(_thing: ICharacter, event?: Event): void {
+    public mouseDownRight(_thing: IPlayer, event?: Event): void {
         this.gameStarter.gameplay.canInputsTrigger(event);
         this.gameStarter.menus.pause.toggle();
         this.gameStarter.modAttacher.fireEvent(this.gameStarter.mods.eventNames.onMouseDownRight);

--- a/src/creators/createQuadsKeeper.ts
+++ b/src/creators/createQuadsKeeper.ts
@@ -3,16 +3,19 @@ import { IQuadrant, QuadsKeepr } from "quadskeepr";
 import { IThing } from "../components/Things";
 import { FullScreenPokemon } from "../FullScreenPokemon";
 
+const numRows = 7;
+const numCols = 7;
+
 export const createQuadsKeeper = (fsp: FullScreenPokemon) => {
-    const quadrantWidth: number = fsp.settings.width / 6;
-    const quadrantHeight: number = fsp.settings.height / 6;
+    const quadrantWidth: number = fsp.settings.width / (numRows - 2);
+    const quadrantHeight: number = fsp.settings.height / (numCols - 2);
 
     return new QuadsKeepr<any>({
         quadrantFactory: (): IQuadrant<IThing> => fsp.objectMaker.make<IQuadrant<IThing>>("Quadrant"),
         quadrantWidth,
         quadrantHeight,
-        numRows: 5,
-        numCols: 6,
+        numRows,
+        numCols,
         groupNames: ["Solid", "Character", "Scenery", "Terrain", "Text"],
         startLeft: -quadrantWidth,
         startTop: -quadrantHeight,


### PR DESCRIPTION
Some learnings from trying the engine out independently.. this makes it so inputs are _always_ prevented.

Fixes #595