### PR TITLE
Ensured player position is always saved when resuming a game

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7681,11 +7681,11 @@
       "dev": true
     },
     "stateholdr": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/stateholdr/-/stateholdr-0.7.3.tgz",
-      "integrity": "sha1-08gdKd73hyPilNkEdpsogyQsAXY=",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/stateholdr/-/stateholdr-0.7.4.tgz",
+      "integrity": "sha512-MqtbOdqkklD/jDtdpnXiGq6ahPywsfcaWrrFiouKQQoodaJiKhVNq0qAn/EytIDW45Zw3QGAvWgJApnF/tkB9Q==",
       "requires": {
-        "itemsholdr": "^0.7.4"
+        "itemsholdr": "^0.7.8"
       }
     },
     "static-extend": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "flagswappr": "^0.7.3",
     "itemsholdr": "^0.7.8",
     "menugraphr": "^0.7.10",
-    "stateholdr": "^0.7.3",
+    "stateholdr": "^0.7.4",
     "stringfilr": "^0.7.4",
     "userwrappr": "^0.7.6"
   },

--- a/src/components/maps/Entrances.test.ts
+++ b/src/components/maps/Entrances.test.ts
@@ -1,0 +1,43 @@
+import { expect } from "chai";
+
+import { stubBlankGame } from "../../fakes.test";
+
+describe("Entrances", () => {
+    describe("resume", () => {
+        it("defaults player position to (0, 0) when not previously saved", () => {
+            // Arrange
+            const { fsp } = stubBlankGame();
+            const zeroCorner = fsp.things.add(fsp.things.names.grass, 0, 0);
+
+            // Act
+            fsp.maps.entrances.resume();
+
+            // Assert
+            expect(fsp.groupHolder.getThing("player")).to.deep.include({
+                left: zeroCorner.left,
+                top: zeroCorner.top,
+            });
+        });
+
+        it("restores player position to the saved value when previously saved", () => {
+            // Arrange
+            const xloc = 40;
+            const yloc = 24;
+            const { fsp } = stubBlankGame();
+            const zeroCorner = fsp.things.add(fsp.things.names.grass, 0, 0);
+
+            fsp.stateHolder.addChange("player", "xloc", xloc);
+            fsp.stateHolder.addChange("player", "yloc", yloc);
+
+            // Act
+            document.body.appendChild(fsp.canvas);
+            fsp.maps.entrances.resume();
+
+            // Assert
+            expect(fsp.groupHolder.getThing("player")).to.deep.include({
+                left: zeroCorner.left + xloc,
+                top: zeroCorner.top + yloc,
+            });
+        });
+    });
+});


### PR DESCRIPTION
### Summary

Brings in a StateHoldr version with a fix for #727. Adds a unit test to make sure it doesn't come back.

Fixes #727.